### PR TITLE
Correct a bunch of W0 registers

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -472,28 +472,28 @@
         <field name="serial" bits="26:24" access="R/W" reset="0">
             Select which serial port is accessed by \Rserrx and \Rsertx.
         </field>
-        <field name="error7" bits="23" access="R" reset="0"/>
+        <field name="error7" bits="23" access="R/W1C" reset="0"/>
         <field name="valid7" bits="22" access="R" reset="0" />
-        <field name="full7" bits="21" access="R/W1C" reset="0" />
-        <field name="error6" bits="20" access="R" reset="0"/>
+        <field name="full7" bits="21" access="R" reset="0" />
+        <field name="error6" bits="20" access="R/W1C" reset="0"/>
         <field name="valid6" bits="19" access="R" reset="0" />
-        <field name="full6" bits="18" access="R/W1C" reset="0" />
-        <field name="error5" bits="17" access="R" reset="0"/>
+        <field name="full6" bits="18" access="R" reset="0" />
+        <field name="error5" bits="17" access="R/W1C" reset="0"/>
         <field name="valid5" bits="16" access="R" reset="0" />
-        <field name="full5" bits="15" access="R/W1C" reset="0" />
-        <field name="error4" bits="14" access="R" reset="0"/>
+        <field name="full5" bits="15" access="R" reset="0" />
+        <field name="error4" bits="14" access="R/W1C" reset="0"/>
         <field name="valid4" bits="13" access="R" reset="0" />
-        <field name="full4" bits="12" access="R/W1C" reset="0" />
-        <field name="error3" bits="11" access="R" reset="0"/>
+        <field name="full4" bits="12" access="R" reset="0" />
+        <field name="error3" bits="11" access="R/W1C" reset="0"/>
         <field name="valid3" bits="10" access="R" reset="0" />
-        <field name="full3" bits="9" access="R/W1C" reset="0" />
-        <field name="error2" bits="8" access="R" reset="0"/>
+        <field name="full3" bits="9" access="R" reset="0" />
+        <field name="error2" bits="8" access="R/W1C" reset="0"/>
         <field name="valid2" bits="7" access="R" reset="0" />
-        <field name="full2" bits="6" access="R/W1C" reset="0" />
-        <field name="error1" bits="5" access="R" reset="0"/>
+        <field name="full2" bits="6" access="R" reset="0" />
+        <field name="error1" bits="5" access="R/W1C" reset="0"/>
         <field name="valid1" bits="4" access="R" reset="0" />
-        <field name="full1" bits="3" access="R/W1C" reset="0" />
-        <field name="error0" bits="2" access="R" reset="0">
+        <field name="full1" bits="3" access="R" reset="0" />
+        <field name="error0" bits="2" access="R/W1C" reset="0">
             1 when the debugger-to-core queue for serial port 0 has
             over or underflowed. This bit will remain set until it is reset by
             writing 1 to this bit.

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -474,25 +474,25 @@
         </field>
         <field name="error7" bits="23" access="R" reset="0"/>
         <field name="valid7" bits="22" access="R" reset="0" />
-        <field name="full7" bits="21" access="R/W0" reset="0" />
+        <field name="full7" bits="21" access="R/W1C" reset="0" />
         <field name="error6" bits="20" access="R" reset="0"/>
         <field name="valid6" bits="19" access="R" reset="0" />
-        <field name="full6" bits="18" access="R/W0" reset="0" />
+        <field name="full6" bits="18" access="R/W1C" reset="0" />
         <field name="error5" bits="17" access="R" reset="0"/>
         <field name="valid5" bits="16" access="R" reset="0" />
-        <field name="full5" bits="15" access="R/W0" reset="0" />
+        <field name="full5" bits="15" access="R/W1C" reset="0" />
         <field name="error4" bits="14" access="R" reset="0"/>
         <field name="valid4" bits="13" access="R" reset="0" />
-        <field name="full4" bits="12" access="R/W0" reset="0" />
+        <field name="full4" bits="12" access="R/W1C" reset="0" />
         <field name="error3" bits="11" access="R" reset="0"/>
         <field name="valid3" bits="10" access="R" reset="0" />
-        <field name="full3" bits="9" access="R/W0" reset="0" />
+        <field name="full3" bits="9" access="R/W1C" reset="0" />
         <field name="error2" bits="8" access="R" reset="0"/>
         <field name="valid2" bits="7" access="R" reset="0" />
-        <field name="full2" bits="6" access="R/W0" reset="0" />
+        <field name="full2" bits="6" access="R/W1C" reset="0" />
         <field name="error1" bits="5" access="R" reset="0"/>
         <field name="valid1" bits="4" access="R" reset="0" />
-        <field name="full1" bits="3" access="R/W0" reset="0" />
+        <field name="full1" bits="3" access="R/W1C" reset="0" />
         <field name="error0" bits="2" access="R" reset="0">
             1 when the debugger-to-core queue for serial port 0 has
             over or underflowed. This bit will remain set until it is reset by
@@ -501,7 +501,7 @@
         <field name="valid0" bits="1" access="R" reset="0">
             1 when the core-to-debugger queue for serial port 0 is not empty.
         </field>
-        <field name="full0" bits="0" access="R/W0" reset="0">
+        <field name="full0" bits="0" access="R" reset="0">
             1 when the debugger-to-core queue for serial port 0 is full.
         </field>
     </register>
@@ -569,7 +569,7 @@
             When 1, every read from \Rsbdatazero automatically triggers a system
             bus read at the new address.
         </field>
-        <field name="sberror" bits="14:12" access="R/W0" reset="0">
+        <field name="sberror" bits="14:12" access="R/W1C" reset="0">
             When the debug module's system bus
             master causes a bus error, this field gets set. The bits in this
             field remain set until they are cleared by writing 1 to them.


### PR DESCRIPTION
Many registers were labeled W0 even though their description stated otherwise. Make them consistent.

Closes #85 along with similar issues found on the way.