### PR TITLE
DPC: Clarifications on its meaning/usage

### DIFF
--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -54,7 +54,10 @@
                specified register.
         </field>
         <field name="regno" bits="15:0">
-            Number of the register to access, as described in Table~\ref{tab:regno}.
+          Number of the register to access, as described in
+          Table~\ref{tab:regno}.
+          \Rdpc may be used as an alias for PC if this command is
+          supported on a non-halted hart.
         </field>
     </register>
 

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -84,11 +84,11 @@
     </register>
 
     <register name="Debug PC" short="dpc" address="0x7b1">
-        This register is only accessible in Debug Mode. Then it contains the
-        address of the next instruction to be executed when resuming. It is
-        writable so that the debugger can cause execution to continue somewhere
-        else.
+        Upon entry to debug mode, \Rdpc is written with the
+        virtual address of the instruction that encountered the exception.
 
+        When resuming, the hart's PC is updated to the virtual address stored in
+        \Rdpc. A debugger may write \Rdpc to change where the hart resumes.
         <field name="dpc" bits="XLEN-1:0" access="R/W" reset="0" />
     </register>
 


### PR DESCRIPTION
Addresses #66,  #75. Also clarifies that DPC behaves like MEPC and friends -- it gets the address of the PC which entered debug mode (not the last instruction which has already completed).  