### PR TITLE
Increase xdebugver field size to 4 bits.

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -1,14 +1,12 @@
 <registers name="Core Debug Registers" prefix="CSR_">
     These registers are only accessible from Debug Mode.
     <register name="Debug Control and Status" short="dcsr" address="0x7b0">
-        <field name="xdebugver" bits="31:30" access="R" reset="Preset">
+        <field name="xdebugver" bits="31:28" access="R" reset="Preset">
           0: There is no external debug support.
 
-          1: External debug support exists as it is described in this document.
-
-	  Other values are reserved for future standards.
+          4: External debug support exists as it is described in this document.
         </field>
-        <field name="0" bits="29:16" access="R" reset="0" />
+        <field name="0" bits="27:16" access="R" reset="0" />
         <field name="ebreakm" bits="15" access="R/W" reset="0">
             When 1, {\tt ebreak} instructions in Machine Mode enter Debug Mode.
         </field>


### PR DESCRIPTION
2 bits isn't really enough for a version field.
Changed the "current version" from 1 to 4 so that existing
implementations aren't affected by this change.

Fixes issue #86.