### PR TITLE
Forward reference for anynonexistent

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -79,7 +79,7 @@ commands are specific to that hart.
 
 A debugger can enumerate all the harts
 attached to the DM by selecting each hart starting from 0
-until \Fanynonexistent is 1.
+until \Fanynonexistent in \Rdmstatus is 1.
 
 The debugger can discover the mapping between hart indices and
 \Rmhartid by using the interface to read \Rmhartid, or by


### PR DESCRIPTION
Since anynonexistent is not referenced earlier, clarify that it it is in dmstatus.

Addresses #65 