### PR TITLE
remove "spontaneous"

### DIFF
--- a/overview.tex
+++ b/overview.tex
@@ -25,7 +25,7 @@ which allows access to additional hart state. Alternatively, additional
 abstract commands can provide access to additional hart state.
 
 Each RISC-V hart may implement a Trigger Module. When trigger conditions
-are met, harts will halt spontaneously and inform the debug module that they have
+are met, harts will halt and inform the debug module that they have
 halted.
 
 An optional system bus access block allows memory accesses without using a


### PR DESCRIPTION
It's not really spontaneous, as the first part of the sentence says, it's because trigger conditions were met.

Addresses #64 