### PR TITLE
jtagdtm: Move it out of the appendix

### DIFF
--- a/dtm.tex
+++ b/dtm.tex
@@ -1,4 +1,3 @@
-
 \chapter{Debug Transport Module (DTM)} \label{dtm}
 
 Debug Transport Modules provide access to the DM over one or more transports
@@ -14,5 +13,7 @@ access to the Debug Module Interface.
 Using multiple DTMs at the same time is not supported. It is left to the user
 to ensure this does not happen.
 
-This specification defines a JTAG DTM in Appendix~\ref{jtagdtm}. Additional DTMs
+This specification defines a JTAG DTM in Section~\ref{sec:jtagdtm}. Additional DTMs
 may be added in future versions of this specification.
+
+\input{jtagdtm}

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -1,11 +1,11 @@
-\chapter{JTAG Debug Transport Module} \label{jtagdtm}
+\section{JTAG Debug Transport Module} \label{sec:jtagdtm}
 
 This Debug Transport Module is based around a normal JTAG Test Access Port
 (TAP).  The JTAG TAP allows access to arbitrary JTAG registers by first
 selecting one using the JTAG instruction register (IR), and then accessing it
 through the JTAG data register (DR).
 
-\section{Background}
+\subsection{JTAG Background}
 
 JTAG refers to IEEE Std 1149.1-2013. It is a standard that defines test logic
 that can be included in an integrated circuit to test the interconnections
@@ -16,7 +16,7 @@ The JTAG standard defines a Test Access Port (TAP) that
 can be used to read and write a few custom registers, which can be used to
 communicate with debug hardware in a component.
 
-\section{JTAG Registers}
+\subsection{JTAG DTM Registers}
 
 JTAG TAPs used as a DTM must have an IR of at least 5 bits.
 When the TAP is reset, IR must default to
@@ -31,7 +31,7 @@ Unimplemented instructions must select the BYPASS register.
 
 \input{jtag_registers.tex}
 
-\section{JTAG Connector}
+\subsection{Recommended JTAG Connector}
 
 To make it easy to
 acquire debug hardware, this spec recommends a connector that is compatible

--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -86,7 +86,6 @@ Version \versionnum\\
 \newpage
 \appendix
 
-\include{jtagdtm}
 \include{implementations}
 \include{debugger_implementation}
 \include{trace}


### PR DESCRIPTION
 as it is really part of the specification.