### PR TITLE
Clarify when you would get error halt/resume

### DIFF
--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -18,8 +18,10 @@
         Debug Modules must implement this command
 	and must support accessing GPRs when the selected hart is halted.
         Debug Modules may optionally support accessing other registers,
-	or accessing registers when the hart is running.
-
+	or accessing registers when the hart is running. If this command is 
+	supported for a register while the hart is running, it must also
+	be supported for a register while the hart is halted.
+	    
         <field name="cmdtype" bits="31:24">
             This is 0 to indicate Access Register Command.
         </field>

--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -16,14 +16,14 @@
         that would cause failure.
 
         Debug Modules must implement this command
-	      and must support read and write access to all GPRs when the selected hart is halted.
+	and must support read and write access to all GPRs when the selected hart is halted.
         Debug Modules may optionally support accessing other registers,
-	      or accessing registers when the hart is running.
+	or accessing registers when the hart is running.
         If this command is 
-	      supported for a register while the hart is running, it must also
-	      be supported for a register while the hart is halted.
-	      Each individual register (aside from GPRs) may be supported differently
-	      across read, write, and halt status.
+	supported for a register while the hart is running, it must also
+	be supported for a register while the hart is halted.
+	Each individual register (aside from GPRs) may be supported differently
+	across read, write, and halt status.
 	
         <field name="cmdtype" bits="31:24">
             This is 0 to indicate Access Register Command.


### PR DESCRIPTION
By adding this clarification, it removes a race/ambiguity about the meaning of error halt/resume for Access Register command