### PR TITLE
Use LL instead of L for 64-bit constant suffix.

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -207,9 +207,9 @@ def write_cheader( fd, registers ):
             if r.width() <= 32:
                 suffix = ""
             else:
-                suffix = "L"
+                suffix = "LL"
         except TypeError:
-            suffix = "L"
+            suffix = "LL"
         for f in r.fields:
             if f.define:
                 if f.description:


### PR DESCRIPTION
See https://github.com/riscv/riscv-openocd/pull/81