### PR TITLE
DMI does not have an Error response

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -26,8 +26,7 @@ or use a more full-featured bus like TileLink or the AMBA Advanced Peripheral
 Bus. The details are left to the system designer.
 
 The DMI uses between 7 and 32 address bits.  It supports read and write
-operations, which may return an error. (Errors are only returned by the optional
-System Bus Access block). The bottom of the address space is
+operations.  The bottom of the address space is
 used for the DM. Extra space can be used for custom debug devices, other cores,
 additional DMs, etc.
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -542,8 +542,7 @@
         If \Fsbasize is 0, then this register is not present.
 
         When the system bus master is busy,
-        writes to this register will return error
-        and \Fsberror is set.
+        writes to this register will set \Fsberror.
 
         If \Fsberror is 0 and \Fsbautoread is set then the system bus
         master will start
@@ -577,12 +576,11 @@
         If all of the {\tt sbaccess} bits in \Rsbcs are 0, then this register
         is not present.
 
-        If \Fsberror isn't 0 then accesses return error, and don't do anything
-        else.
-
+        If \Fsberror isn't 0 then accesses do nothing.
+        
         Writes to this register:
 
-        1. If the bus master is busy then accesses set \Fsberror, return error,
+        1. If the bus master is busy then accesses set \Fsberror,
         and don't do anything else.
 
         2. Update internal data.
@@ -594,8 +592,8 @@
         Reads from this register:
 
         1. If bits 31:0 of the internal data register haven't been updated
-        since the last time this register was read, then set \Fsberror, return
-        error, and don't do anything else.
+        since the last time this register was read, then set \Fsberror,
+	and don't do anything else.
 
         2. ``Return'' the data.
 

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -136,8 +136,10 @@
             this access will be ignored.  This status is sticky and can be
             cleared by writing \Fdmireset in \Rdtmcs.
 
-            This indicates that the DM itself responded with an error, e.g.
-            in the System Bus and Serial Port overflow/underflow cases.
+            This indicates that the DM itself responded with an error.
+	    Note: there are no specified cases in which the DM would
+	    respond with an error, and DMI is not required to support
+	    returning errors.
 
             3: An operation was attempted while a DMI request is still in
             progress. The data scanned into \Rdmi in this access will be


### PR DESCRIPTION
Closes #116 

There really is no reason to have DMI return error responses, as in all other error cases a sticky error status bit is set. The only one left here was for System Bus access. This PR removes this last remaining case.