### PR TITLE
Correct plurality of halted harts in haltsum

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -259,7 +259,7 @@
         Each bit contains the logical OR of 32 halt bits. When there are a
         large number of harts in the system, the debugger can first read this
         register, and then read from the halt region (0x40--0x5f) to determine
-        which hart is the one that is halted.
+        which harts are halted.
 
         <field name="halt31:0" bits="0" access="R" reset="0" />
         <field name="halt63:32" bits="1" access="R" reset="0" />


### PR DESCRIPTION
Since more than one hart can be halted at a  time, correct this statement.