### PR TITLE
Python interpreter to be used should default to Python2

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import xml.etree.ElementTree


### PR DESCRIPTION
Make fails on systems with python3 interpreter linked to python