### PR TITLE
Change dcsr.prv reset value to 3

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -79,7 +79,7 @@
             the hart will immediately enter Debug Mode before executing
             the trap handler, with appropriate exception registers set.
         </field>
-        <field name="prv" bits="1:0" access="R/W" reset="0">
+        <field name="prv" bits="1:0" access="R/W" reset="3">
             Contains the privilege level the hart was operating in when Debug
             Mode was entered. The encoding is described in Table
             \ref{tab:privlevel}.  A debugger can change this value to change


### PR DESCRIPTION
This will help avoid a trap where an implementation might end up with
prv 0 when entering debug out of reset. Even in that case prv should be
set from the privilege mode of the processor, which should be machine
mode, but specifying this as the actual value makes things a little
simpler.