### PR TITLE
haltsum1: correct its address 

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -495,7 +495,7 @@
         <field name="haltsum0" bits="31:0" access="R" reset="0" />
     </register>
 
-    <register name="Halt Summary 1" short="haltsum1" address="0x18">
+    <register name="Halt Summary 1" short="haltsum1" address="0x13">
         Each bit in this read-only register indicates whether any of a group of
         harts is halted or not.
 


### PR DESCRIPTION
to be BWC and not overlap with ABSTRACTAUTO.

Fixes typo introduced in #218 