### PR TITLE
Force the register-address table in place.

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -16,6 +16,7 @@
 \usepackage{algorithmicx}
 \usepackage{program}
 \usepackage[nochapter]{vhistory}
+\usepackage{float}
 % If LaTeX just doesn't do what I want, buy http://www.amazon.com/gp/product/0201362996
 
 % Used for tables that can span pages:
@@ -29,9 +30,8 @@
 \newenvironment{steps}[1]
   {
      \vspace{1ex}
-     \noindent
-     #1
-     \begin{enumerate}
+     \noindent #1
+     \begin{enumerate}[nolistsep]
   }
   {
      \end{enumerate}

--- a/registers.py
+++ b/registers.py
@@ -323,7 +323,9 @@ def compare_address(a, b):
 
 def print_latex_index( registers ):
     print registers.description
-    print "\\begin{table}[htp]"
+    # Force this table HERE so that it doesn't get moved into the next section,
+    # which will be the description of a register.
+    print "\\begin{table}[H]"
     print "   \\begin{center}"
     print "      \\caption{%s}" % registers.name
     print "      \\label{%s}" % registers.label


### PR DESCRIPTION
Previously it was confusing that especially Table 3.8 would end up in
the dmstatus Section. #300