### PR TITLE
Completing progbuf exec is I/O for fence insts.

### DIFF
--- a/core_debug.tex
+++ b/core_debug.tex
@@ -33,6 +33,8 @@ external debugging. How Debug Mode is implemented is not specified here.
     and {\tt uret}.  (To change the privilege level, the debugger can write
     \Fprv in \Rdcsr). The only exception is {\tt ebreak}. When that is executed
     in Debug Mode, it halts the hart again but without updating \Rdpc or \Rdcsr.
+\item Completing Program Buffer execution is considered I/O for the purpose of
+    {\tt fence} instructions.
 \end{steps}
 
 \section{Load-Reserved/Store-Conditional Instructions}


### PR DESCRIPTION
We need something like this so a debugger can ensure a memory change is
propagated to all harts in a system.