### PR TITLE
Add dcsr.progbufjump.

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -15,8 +15,7 @@
           15: There is external debug support, but it does not conform to any
           available version of this spec.
         </field>
-        <field name="0" bits="27:18" access="R" reset="0" />
-        <field name="progbufjump" bits="17:16" access="R" reset="Preset">
+        <field name="progbufjump" bits="27:26" access="R" reset="Preset">
             0: All control transfer instructions are supported in the Program
             Buffer.
 
@@ -28,6 +27,7 @@
             3: No control transfer instructions are supported in the Program
             Buffer. Instead they act as illegal instructions.
         </field>
+        <field name="0" bits="25:16" access="R" reset="0" />
         <field name="ebreakm" bits="15" access="R/W" reset="0">
             When 1, {\tt ebreak} instructions in Machine Mode enter Debug Mode.
         </field>

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -15,7 +15,17 @@
           15: There is external debug support, but it does not conform to any
           available version of this spec.
         </field>
-        <field name="0" bits="27:16" access="R" reset="0" />
+        <field name="0" bits="27:18" access="R" reset="0" />
+        <field name="progbufjump" bits="17:16" access="R" reset="Preset">
+            0: All jumps/branches are supported in the Program Buffer.
+
+            1: Jumps/branches in the Program Buffer are supported as long as
+            their destination is also in the Program Buffer. Other
+            jumps/branches act as illegal instructions.
+
+            3: No jumps/branches are supported in the Program Buffer. Instead
+            they act as illegal instructions.
+        </field>
         <field name="ebreakm" bits="15" access="R/W" reset="0">
             When 1, {\tt ebreak} instructions in Machine Mode enter Debug Mode.
         </field>

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -17,14 +17,16 @@
         </field>
         <field name="0" bits="27:18" access="R" reset="0" />
         <field name="progbufjump" bits="17:16" access="R" reset="Preset">
-            0: All jumps/branches are supported in the Program Buffer.
+            0: All control transfer instructions are supported in the Program
+            Buffer.
 
-            1: Jumps/branches in the Program Buffer are supported as long as
-            their destination is also in the Program Buffer. Other
-            jumps/branches act as illegal instructions.
+            1: Control transfer instructions in the Program Buffer are
+            supported as long as their destination is also in the Program
+            Buffer. Other control transfer instructions act as illegal
+            instructions.
 
-            3: No jumps/branches are supported in the Program Buffer. Instead
-            they act as illegal instructions.
+            3: No control transfer instructions are supported in the Program
+            Buffer. Instead they act as illegal instructions.
         </field>
         <field name="ebreakm" bits="15" access="R/W" reset="0">
             When 1, {\tt ebreak} instructions in Machine Mode enter Debug Mode.


### PR DESCRIPTION
This is needed to support instruction stuffing implementations, where
adding jumps to the Program Buffer doesn't make any sense.

Fixes #314.