### PR TITLE
Allow extra harts to be reset.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -75,8 +75,7 @@ an arbitrarily long time to come out of reset, as reported by \Fallunavail,
 
 Individual harts (or several at once) can be reset by selecting them, setting
 and then clearing \Fhartreset. In this case an implementation may reset more
-harts than just the ones that are selected. Whether these extra harts halt or
-run out of reset is determined by the current value of \Fhaltreq.
+harts than just the ones that are selected.
 
 When harts have been reset, they must set a sticky {\tt havereset} state bit.
 The conceptual {\tt havereset} state bits can be read for selected harts in

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -73,6 +73,11 @@ a write of \Fndmreset to 0 triggers system reset. The system may take
 an arbitrarily long time to come out of reset, as reported by \Fallunavail,
 \Fanyunavail, or other implementation specific indicators.
 
+Individual harts (or several at once) can be reset by selecting them, setting
+and then clearing \Fhartreset. In this case an implementation may reset more
+harts than just the ones that are selected. Whether these extra harts halt or
+run out of reset is determined by the current value of \Fhaltreq.
+
 When harts have been reset, they must set a sticky {\tt havereset} state bit.
 The conceptual {\tt havereset} state bits can be read for selected harts in
 \Fanyhavereset and \Fallhavereset in \Rdmstatus.


### PR DESCRIPTION
Based on feedback by Allen that resetting just one hart in a multi-hart
core can be complex/poorly defined, depending on implementation.