### PR TITLE
m "LaTeX/english issues: eg. -> e.g., etc"

### DIFF
--- a/core_debug.tex
+++ b/core_debug.tex
@@ -43,7 +43,7 @@ external debugging. How Debug Mode is implemented is not specified here.
     their destination is outside the Program Buffer. If one such instruction
     acts as an illegal instruction, all such instructions must act as an
     illegal instruction.
-\item Instructions that depend on the value of the PC (eg. {\tt auipc}) may act
+\item Instructions that depend on the value of the PC (e.g.\ {\tt auipc}) may act
     as illegal instructions.
 \end{steps}
 

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -205,7 +205,7 @@ specified.
     the target and commands succeed, which allows for maximum throughput. If
     there is a failure, the interface ensures that no commands execute after
     the failing one.  To discover which command failed, the debugger has to
-    look at the state of the DM (eg. contents of \Rdatazero) or hart (eg.
+    look at the state of the DM (e.g.\ contents of \Rdatazero) or hart (e.g.\ 
     contents of a register modified by a Program Buffer program) to determine
     which one failed.
 \end{commentary}
@@ -452,7 +452,7 @@ When read, unimplemented Debug Module DMI Registers return 0. Writing them has
 no effect.
 
 For each register it is possible to determine that it is implemented by reading
-it and getting a non-zero value (eg. \Rsbcs), or by checking bits in another
-register (eg. \Fprogbufsize).
+it and getting a non-zero value (e.g.\ \Rsbcs), or by checking bits in another
+register (e.g.\ \Fprogbufsize).
 
 \input{dm_registers.tex}

--- a/debugger_implementation.tex
+++ b/debugger_implementation.tex
@@ -35,7 +35,7 @@ inefficiency in typical JTAG use.
 
 \section{Checking for Halted Harts}
 
-A user will want to know as quickly as possible when a hart is halted (eg. due
+A user will want to know as quickly as possible when a hart is halted (e.g.\ due
 to a breakpoint).  To efficiently determine which harts are halted when there
 are many harts, the debugger uses the {\tt haltsum} registers. Assuming the
 maximum number of harts exist, first it checks \Rhaltsumthree. For each bit set
@@ -573,7 +573,7 @@ executed, to be used as an instruction breakpoint in ROM:
 \section{Handling Exceptions}
 
 Generally the debugger can avoid exceptions by being careful with the programs
-it writes. Sometimes they are unavoidable though, eg. if the user asks to
+it writes. Sometimes they are unavoidable though, e.g.\ if the user asks to
 access memory or a CSR that is not implemented. A typical debugger will not
 know enough about the platform to know what's going to happen, and must attempt
 the access to determine the outcome.

--- a/dtm.tex
+++ b/dtm.tex
@@ -1,7 +1,7 @@
 \chapter{Debug Transport Module (DTM)} \label{dtm}
 
 Debug Transport Modules provide access to the DM over one or more transports
-(eg. JTAG or USB).
+(e.g.\ JTAG or USB).
 
 There may be multiple DTMs in a single platform. Ideally every component that
 communicates with the outside world includes a DTM, allowing a platform to be

--- a/future.tex
+++ b/future.tex
@@ -20,7 +20,7 @@ Some future version of this spec may implement some of the following features.
    \item Serial ports can raise an interrupt when a send/receive queue becomes full/empty.
    \item The debug interrupt can be masked by running code. If the interrupt is
       asserted, then deasserted, and then asserted again the debug interrupt
-      happens anyway. This mechanism can be used to eg. read/write memory with
+      happens anyway. This mechanism can be used to e.g.\ read/write memory with
       minimal interruption, making sure never to interrupt during a critical
       piece of code.
    \item The Debug Module can include a serial interface for re-using

--- a/implementations.tex
+++ b/implementations.tex
@@ -63,7 +63,7 @@ privilege set by \Fprv.
 \Rdatazero etc. are mapped into regular memory at an address relative to \Rzero
 with only a 12-bit {\tt imm}. The exact address is an implementation
 detail that a debugger must not rely on. For example, the {\tt data}
-registers might be mapped to $0x400$.
+registers might be mapped to {\tt 0x400}.
 
 For additional flexibility, \Rprogbufzero, etc. are mapped into regular memory
 immediately preceding \Rdatazero, in order to form a contiguous region of memory which

--- a/introduction.tex
+++ b/introduction.tex
@@ -8,7 +8,7 @@ it is critical to have good debugging support built into the hardware.
 When a robust OS is running on a core, software can handle many
 debugging tasks. However, in many scenarios, hardware support is essential.
 
-This document outlines a standard architecture for external debug support 
+This document outlines a standard architecture for external debug support
 on RISC-V platforms. This architecture allows a variety of implementations and
 tradeoffs, which is complementary to the wide range of RISC-V implementations.
 At the same time, this specification defines common interfaces to
@@ -127,7 +127,7 @@ The debugger can read and/or modify state, then direct the hardware
 to execute a single instruction, or continue to run freely.
 
 The second is \emph{run mode} debugging. In this mode a software
-debug agent runs on a component (eg.  triggered by a timer interrupt or breakpoint
+debug agent runs on a component (e.g.\ triggered by a timer interrupt or breakpoint
 on a RISC-V core) which transfers data to or from the debugger
 without halting the component, only briefly interrupting its program flow.
 This functionality is essential if the component is controlling some real-time system (like a

--- a/overview.tex
+++ b/overview.tex
@@ -10,10 +10,10 @@ Blocks shown in dotted lines are optional.
    \label{fig:overview}
 \end{figure}
 
-The user interacts with the Debug Host (eg. laptop), which is running a
-debugger (eg. gdb).  The debugger communicates with a Debug Translator (eg.
+The user interacts with the Debug Host (e.g.\ laptop), which is running a
+debugger (e.g.\ gdb).  The debugger communicates with a Debug Translator (e.g.\ 
 OpenOCD, which may include a hardware driver) to communicate with Debug
-Transport Hardware (eg.  Olimex USB-JTAG adapter).
+Transport Hardware (e.g.\ Olimex USB-JTAG adapter).
 The Debug Transport Hardware connects the Debug Host to the Platform's Debug
 Transport Module (DTM).  The DTM provides access to one or more Debug Modules
 (DMs) using the Debug Module Interface (DMI).

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -9,13 +9,13 @@
         changed from version 0.11 of this spec.
 
         Harts are nonexistent if they will never be part of this system, no
-        matter how long a user waits. Eg. in a simple single-hart system only
+        matter how long a user waits. E.g.\ in a simple single-hart system only
         one hart exists, and all others are nonexistent. Debuggers may assume
         that a system has no harts with indexes higher than the first
         nonexistent one.
 
         Harts are unavailable if they might exist/become available at a later
-        time, or if there are other harts with higher indexes than this one. Eg.
+        time, or if there are other harts with higher indexes than this one. E.g.\
         in a multi-hart system some might temporarily be powered down, or a
         system might support hot-swapping harts. Systems with very large number
         of harts may permanently disable some during manufacturing, leaving
@@ -303,7 +303,7 @@
       <field name="0" bits="31:15" access="R/W" reset="0" />
       <field name="hawindowsel" bits="14:0" access="R/W" reset="0">
           The high bits of this field may be tied to 0, depending on how large
-          the array mask register is.  Eg. on a system with 48 harts only bit 0
+          the array mask register is.  E.g.\ on a system with 48 harts only bit 0
           of this field may actually be writable.
       </field>
     </register>
@@ -362,12 +362,12 @@
             regardless of whether the hart is running or not.
 
             3 (exception): An exception occurred while executing the command
-            (eg. while executing the Program Buffer).
+            (e.g.\ while executing the Program Buffer).
 
             4 (halt/resume): The abstract command couldn't execute because the
             hart wasn't in the required state (running/halted).
 
-            5 (bus): The abstract command failed due to a bus error (eg.
+            5 (bus): The abstract command failed due to a bus error (e.g.\ 
             alignment, access size, timeout).
 
             7 (other): The command failed for another reason.


### PR DESCRIPTION
Note, the e.g. must be followed by a backslash to tell LaTeX that it
isn't the end of a sentence.

$0x400$ tells LaTeX to read "0 x 400" as math, not what you want