### PR TITLE
Language, formatting, and abstract cmd arguments.

### DIFF
--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -11,6 +11,7 @@
             {\tt arg0} region of {\tt data} into the register specified by
             \Fregno, and perform any side effects that occur when this register
             is written from M mode.
+        \item If \Faarpostincrement is set, increment \Fregno.
         \item Execute the Program Buffer, if \Fpostexec is set.
         \end{steps}
 
@@ -52,6 +53,9 @@
         \begin{commentary}
             The encoding of \Faarsize was chosen to match \Fsbaccess in \Rsbcs.
         \end{commentary}
+
+        This command modifies {\tt arg0} only when a register is read. The
+        other {\tt data} registers are not changed.
 
         <field name="cmdtype" bits="31:24">
             This is 0 to indicate Access Register Command.
@@ -121,6 +125,8 @@
 
         Implementing this command is optional.
 
+        This command does not touch the {\tt data} registers.
+
         <field name="cmdtype" bits="31:24">
             This is 1 to indicate Quick Access command.
         </field>
@@ -137,7 +143,7 @@
             {\tt arg0} portion of {\tt data}, if \Fwrite is clear.
         \item Copy data from the {\tt arg0} portion of {\tt data} into the
             memory location specified in {\tt arg1}, if \Fwrite is set.
-        \item Increment {\tt arg1}, if \Faampostincrement is set.
+        \item If \Faampostincrement is set, increment {\tt arg1}.
         \end{steps}
 
         If any of these operations fail, \Fcmderr is set and none of the
@@ -157,6 +163,10 @@
         \begin{commentary}
             The encoding of \Faamsize was chosen to match \Fsbaccess in \Rsbcs.
         \end{commentary}
+
+        This command modifies {\tt arg0} only when memory is read. It modifies
+        {\tt arg1} only if \Faampostincrement is set.  The other {\tt data}
+        registers are not changed.
 
         <field name="cmdtype" bits="31:24">
             This is 2 to indicate Access Memory Command.

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -19,49 +19,56 @@
         </field>
         <field name="0" bits="21:20" access="R" reset="0" />
         <field name="allhavereset" bits="19" access="R" reset="-">
-          This field is 1 when all currently selected harts have been reset but the reset has not been acknowledged.
+            This field is 1 when all currently selected harts have been reset
+            and reset has not been acknowledged for any of them.
         </field>
         <field name="anyhavereset" bits="18" access="R" reset="-">
-          This field is 1 when any currently selected hart has been reset but the reset has not been acknowledged.
+            This field is 1 when at least one currently selected hart has been
+            reset and reset has not been acknowledged for that hart.
         </field>
         <field name="allresumeack" bits="17" access="R" reset="-">
             This field is 1 when all currently selected harts have acknowledged
-            the previous resume request.
+            their last resume request.
         </field>
         <field name="anyresumeack" bits="16" access="R" reset="-">
             This field is 1 when any currently selected hart has acknowledged
-            the previous resume request.
+            its last resume request.
         </field>
         <field name="allnonexistent" bits="15" access="R" reset="-">
-          This field is 1 when all currently selected harts do not exist in this system.
+            This field is 1 when all currently selected harts do not exist in
+            this platform.
         </field>
         <field name="anynonexistent" bits="14" access="R" reset="-">
-          This field is 1 when any currently selected hart does not exist in this system.
+            This field is 1 when any currently selected hart does not exist in
+            this platform.
         </field>
         <field name="allunavail" bits="13" access="R" reset="-">
-          This field is 1 when all currently selected harts are unavailable.
+            This field is 1 when all currently selected harts are unavailable.
         </field>
         <field name="anyunavail" bits="12" access="R" reset="-">
-          This field is 1 when any currently selected hart is unavailable.
+            This field is 1 when any currently selected hart is unavailable.
         </field>
         <field name="allrunning" bits="11" access="R" reset="-">
-          This field is 1 when all currently selected harts are running.
+            This field is 1 when all currently selected harts are running.
         </field>
         <field name="anyrunning" bits="10" access="R" reset="-">
-          This field is 1 when any currently selected hart is running.
+            This field is 1 when any currently selected hart is running.
         </field>
         <field name="allhalted" bits="9" access="R" reset="-">
-          This field is 1 when all currently selected harts are halted.
+            This field is 1 when all currently selected harts are halted.
         </field>
         <field name="anyhalted" bits="8" access="R" reset="-">
-          This field is 1 when any currently selected hart is halted.
+            This field is 1 when any currently selected hart is halted.
         </field>
 
         <!-- Fields that apply to the entire DM. -->
         <field name="authenticated" bits="7" access="R" reset="Preset">
-            0 when authentication is required before using the DM.  1 when the
-            authentication check has passed. On components that don't implement
-            authentication, this bit must be preset as 1.
+            0: Authentication is required before using the DM.
+
+            1: The authentication check has passed.
+
+            On components that don't implement authentication, this bit must be
+            preset as 1.
         </field>
         <field name="authbusy" bits="6" access="R" reset="0">
             0: The authentication module is ready to process the next
@@ -169,12 +176,13 @@
         </field>
         <field name="0" bits="27" access="R" reset="0" />
         <field name="hasel" bits="26" access="R/W" reset="0">
-            Selects the  definition of currently selected harts.
+            Selects the definition of currently selected harts.
 
-            0: There is a single currently selected hart, that selected by \Fhartsel.
+            0: There is a single currently selected hart, that is selected by \Fhartsel.
 
-            1: There may be multiple currently selected harts -- that selected by \Fhartsel,
-               plus those selected by the hart array mask register.
+            1: There may be multiple currently selected harts -- the hart
+            selected by \Fhartsel, plus those selected by the hart array mask
+            register.
 
             An implementation which does not implement the hart array mask register
             must tie this field to 0. A debugger which wishes to use the hart array
@@ -235,9 +243,9 @@
             A debugger may pulse this bit low to get the Debug Module into a
             known state.
 
-            Implementations may use this bit to aid debugging, for example by
-            preventing the Debug Module from being power gated while debugging
-            is active.
+            Implementations may pay attention to this bit to further aid
+            debugging, for example by preventing the Debug Module from being
+            power gated while debugging is active.
         </field>
     </register>
 
@@ -262,15 +270,15 @@
         </field>
         <field name="0" bits="19:17" access="R" reset="0" />
         <field name="dataaccess" bits="16" access="R" reset="Preset">
-            0: The {\tt data} registers are shadowed in the hart by CSR
-            registers. Each CSR register is DXLEN bits in size, and corresponds
+            0: The {\tt data} registers are shadowed in the hart by CSRs.
+            Each CSR is DXLEN bits in size, and corresponds
             to a single argument, per Table~\ref{tab:datareg}.
 
             1: The {\tt data} registers are shadowed in the hart's memory map.
             Each register takes up 4 bytes in the memory map.
         </field>
         <field name="datasize" bits="15:12" access="R" reset="Preset">
-            If \Fdataaccess is 0: Number of CSR registers dedicated to
+            If \Fdataaccess is 0: Number of CSRs dedicated to
             shadowing the {\tt data} registers.
 
             If \Fdataaccess is 1: Number of 32-bit words in the memory map
@@ -348,7 +356,7 @@
             0 (none): No error.
 
             1 (busy): An abstract command was executing while \Rcommand,
-            \Rabstractcs, \Rabstractauto was written, or when one
+            \Rabstractcs, or \Rabstractauto was written, or when one
             of the {\tt data} or {\tt progbuf} registers was read or written.
             This status is only written if \Fcmderr contains 0.
 
@@ -362,7 +370,7 @@
             hart wasn't in the required state (running/halted), or unavailable.
 
             5 (bus): The abstract command failed due to a bus error (e.g.\ 
-            alignment, access size, timeout).
+            alignment, access size, or timeout).
 
             7 (other): The command failed for another reason.
         </field>
@@ -589,18 +597,6 @@
 
     <!-- =============== system bus mastering =============== -->
 
-    <register name="System Bus Address 127:96" short="sbaddress3" address="0x37">
-        If \Fsbasize is less than 97, then this register is not present.
-
-        When the system bus master is busy, writes to this register will set
-        \Fsbbusyerror and don't do anything else.
-
-        <field name="address" bits="31:0" access="R/W" reset="0">
-            Accesses bits 127:96 of the physical address in {\tt sbaddress} (if
-            the system address bus is that wide).
-        </field>
-    </register>
-
     <register name="System Bus Access Control and Status" short="sbcs" address="0x38">
         <field name="sbversion" bits="31:29" access="R" reset="1">
             0: The System Bus interface conforms to mainline drafts of this
@@ -617,7 +613,7 @@
             already in progress (while \Fsbbusy is set). It remains set until
             it's explicitly cleared by the debugger.
 
-            While this field is non-zero, no more system bus accesses can be
+            While this field is set, no more system bus accesses can be
             initiated by the Debug Module.
         </field>
         <field name="sbbusy" bits="21" access="R" reset="0">
@@ -740,6 +736,18 @@
 
         <field name="address" bits="31:0" access="R/W" reset="0">
             Accesses bits 95:64 of the physical address in {\tt sbaddress} (if
+            the system address bus is that wide).
+        </field>
+    </register>
+
+    <register name="System Bus Address 127:96" short="sbaddress3" address="0x37">
+        If \Fsbasize is less than 97, then this register is not present.
+
+        When the system bus master is busy, writes to this register will set
+        \Fsbbusyerror and don't do anything else.
+
+        <field name="address" bits="31:0" access="R/W" reset="0">
+            Accesses bits 127:96 of the physical address in {\tt sbaddress} (if
             the system address bus is that wide).
         </field>
     </register>


### PR DESCRIPTION
Explicitly state which arguments abstract commands do or do not change.