### PR TITLE
Reset dmi.op to 0 instead of 2.

### DIFF
--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -110,7 +110,7 @@
             The data to send to the DM over the DMI during Update-DR, and
             the data returned from the DM as a result of the previous operation.
         </field>
-        <field name="op" bits="1:0" access="R/W" reset="2">
+        <field name="op" bits="1:0" access="R/W" reset="0">
             When the debugger writes this field, it has the following meaning:
 
             0: Ignore \Fdata and \Faddress. (nop)


### PR DESCRIPTION
Now it's consistent with dtmcs.dmistat.

This reverts 7f0f09a0. It is no longer true that a debugger can assume
dmi.data contains a valid value unless a read was explicitly executed,
so there's no sense in accommodating that case.