### PR TITLE
Clarify W1.

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -84,7 +84,8 @@ indexed on page \pageref{index}.
         \hline
         W & Write-only. When read this field returns 0. \\
         \hline
-        W1 & Write-only. Only writing 1 has an effect. \\
+        W1 & Write-only. Every time that 1 is written an action is taken. When
+        read this field returns 0. \\
         \hline
         WARL & Write any, read legal. A debugger may write any value. If a
         value is unsupported, the implementation converts the value to one that

--- a/introduction.tex
+++ b/introduction.tex
@@ -84,8 +84,7 @@ indexed on page \pageref{index}.
         \hline
         W & Write-only. When read this field returns 0. \\
         \hline
-        W1 & Write-only. Every time that 1 is written an action is taken. When
-        read this field returns 0. \\
+        W1 & Write-only. Only writing 1 has an effect. \\
         \hline
         WARL & Write any, read legal. A debugger may write any value. If a
         value is unsupported, the implementation converts the value to one that

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -198,7 +198,7 @@
             select. This hart is always part of the currently selected harts.
         </field>
         <field name="0" bits="5:4" access="R" reset="0" />
-        <field name="setresethaltreq" bits="3" access="W1" reset="0">
+        <field name="setresethaltreq" bits="3" access="W1" reset="-">
             This optional field writes the halt-on-reset request bit for all
             currently selected harts, unless \Fclrresethaltreq is
             simultaneously set to 1.
@@ -210,7 +210,7 @@
 
             If \Fhasresethaltreq is 0, this field is not implemented.
         </field>
-        <field name="clrresethaltreq" bits="2" access="W1" reset="0">
+        <field name="clrresethaltreq" bits="2" access="W1" reset="-">
             This optional field clears the halt-on-reset request bit for all
             currently selected harts.
 

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -27,7 +27,7 @@
         The size of this register will remain constant in future versions so
         that a debugger can always determine the version of the DTM.
         <field name="0" bits="31:18" access="R" reset="0" />
-        <field name="dmihardreset" bits="17" access="W1" reset="0">
+        <field name="dmihardreset" bits="17" access="W1" reset="-">
           Writing 1 to this bit does a hard reset of the DTM,
           causing the DTM to forget about any outstanding DMI transactions.
           In general this should only be used when the Debugger has
@@ -35,7 +35,7 @@
           complete (e.g. a reset condition caused an inflight DMI transaction to
           be cancelled).
         </field>
-        <field name="dmireset" bits="16" access="W1" reset="0">
+        <field name="dmireset" bits="16" access="W1" reset="-">
           Writing 1 to this bit clears the sticky error state
           and allows the DTM to retry or complete the previous
           transaction.


### PR DESCRIPTION
The definition used to be vague. I think this is the one that makes the
most sense, and shouldn't cause any problems. (Possibly we don't want
this for ackhavereset. I sent e-mail about that.)

The bits that are defined as W1 are:
DM: ackhavreset, setresethaltreq, clrresethaltreq
JTAG: dmihardreset, dmireset