### PR TITLE
Make haltreq stateful again for halt-on-reset.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -165,34 +165,30 @@ deasserted. Finally they end up either running or halted, depending on
 
 \section{Run Control} \label{runcontrol}
 
-For every hart, the Debug Module contains 3 conceptual bits of state: halt
-request, halt-on-reset request, and hart reset.  (The hart reset and
-halt-on-reset request bits are optional.) These bits all reset to 0. In
-addition there are resume request signal and clear resume ack signals.
-A debugger can write these bits/signals for the currently selected
-harts through \Fhaltreq, \Fresumereq, \Fsetresethaltreq/\Fclrresethaltreq, and
-\Fhartreset in \Rdmcontrol.
-In addition the DM receives halted, running, and resume ack signals from each
-hart.
+For every hart, the Debug Module contains 4 conceptual bits of state: halt
+request, resume ack, halt-on-reset request, and hart reset.  (The hart reset
+and halt-on-reset request bits are optional.) These bits all reset to 0. In
+addition there is a resume request signal.  A debugger can write these
+bits/signals for the currently selected harts through \Fhaltreq, \Fresumereq,
+\Fsetresethaltreq/\Fclrresethaltreq, and \Fhartreset in \Rdmcontrol.  In
+addition the DM receives halted and running signals from each hart.
 
 % In my head bits imply flip-flops, while signals might just be the output of
 % combinational logic/state machine. Does that need more clarification?
 
 To halt a hart, the debugger writes 1 to \Fhaltreq, which sets the halt request
-bit for each selected hart. When a running hart sees a halt request, it responds
-by halting,
-deasserting its running signal, and asserting its halted signal. The halted
-signals of all selected harts are reflected in the \Fallhalted and \Fanyhalted
-bits. Halted harts ignore the halt request bit.
+bit for each selected hart. Whenever a running hart sees its halt request bit
+high, it responds by halting, deasserting its running signal, and asserting its
+halted signal. The halted signals of all selected harts are reflected in the
+\Fallhalted and \Fanyhalted bits. Halted harts ignore the halt request bit.
 
 To resume a hart, the debugger writes 1 to \Fresumereq and 0 to \Fhaltreq. This
-causes the DM to send each selected hart a resume request.
-The selected, halted harts respond by resuming, clearing
-their halted signals, and asserting their running and resume ack signals. To
-clear resume ack, the debugger writes 0 to \Fresumereq, which results in the
-DM sending a clear resume ack signal to the hart.  These
-status signals of all selected harts are reflected in \Fallresumeack,
-\Fanyresumeack, \Fallrunning, and \Fanyrunning.
+causes the DM to send each selected hart a resume request, and to clear resume
+ack for each selected hart.  The selected, halted harts respond by resuming,
+clearing their halted signals, and asserting their running signals. The DM
+reacts to a hart's running signal going high by setting resume ack for that
+hart.  These status signals of all selected harts are reflected in
+\Fallresumeack, \Fanyresumeack, \Fallrunning, and \Fanyrunning.
 
 When halt or resume is requested, a hart must respond in
 less than one second, unless it is unavailable.

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -169,7 +169,7 @@ For every hart, the Debug Module contains 4 conceptual bits of state: halt
 request, resume ack, halt-on-reset request, and hart reset.  (The hart reset
 and halt-on-reset request bits are optional.) These bits all reset to 0. In
 addition there is a resume request signal.  A debugger can write these
-bits/signals for the currently selected harts through \Fhaltreq, \Fresumereq,
+bits/signals for the currently selected harts through \Fhaltreq,
 \Fsetresethaltreq/\Fclrresethaltreq, and \Fhartreset in \Rdmcontrol.  In
 addition the DM receives halted and running signals from each hart.
 

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -165,26 +165,34 @@ deasserted. Finally they end up either running or halted, depending on
 
 \section{Run Control} \label{runcontrol}
 
-For every hart, the Debug Module contains 4 conceptual bits of state: halt
-request, resume request, halt-on-reset request,  and hart reset.
-(The hart reset and halt-on-reset request bits are optional.)
-These bits all reset to 0. A debugger can write them for the currently selected
-harts through \Fhaltreq, \Fresumereq, \Fsetresethaltreq/\Fclrresethaltreq and
-\Fhartreset in \Rdmcontrol, only one of which may be high in any single write.
+For every hart, the Debug Module contains 3 conceptual bits of state: halt
+request, halt-on-reset request, and hart reset.  (The hart reset and
+halt-on-reset request bits are optional.) These bits all reset to 0. In
+addition there are resume request signal and clear resume ack signals.
+A debugger can write these bits/signals for the currently selected
+harts through \Fhaltreq, \Fresumereq, \Fsetresethaltreq/\Fclrresethaltreq, and
+\Fhartreset in \Rdmcontrol.
 In addition the DM receives halted, running, and resume ack signals from each
 hart.
 
-When a running hart receives a halt request, it responds by halting,
+% In my head bits imply flip-flops, while signals might just be the output of
+% combinational logic/state machine. Does that need more clarification?
+
+To halt a hart, the debugger writes 1 to \Fhaltreq, which sets the halt request
+bit for each selected hart. When a running hart sees a halt request, it responds
+by halting,
 deasserting its running signal, and asserting its halted signal. The halted
 signals of all selected harts are reflected in the \Fallhalted and \Fanyhalted
-bits. \Fhaltreq is ignored by halted harts.
+bits. Halted harts ignore the halt request bit.
 
-When a halted hart receives a resume request, it responds by resuming, clearing
-its halted signal, and asserting its running signal and resume ack signals. The
-resume ack signal is lowered when the resume request is deasserted.  These
+To resume a hart, the debugger writes 1 to \Fresumereq and 0 to \Fhaltreq. This
+causes the DM to send each selected hart a resume request.
+The selected, halted harts respond by resuming, clearing
+their halted signals, and asserting their running and resume ack signals. To
+clear resume ack, the debugger writes 0 to \Fresumereq, which results in the
+DM sending a clear resume ack signal to the hart.  These
 status signals of all selected harts are reflected in \Fallresumeack,
-\Fanyresumeack, \Fallrunning, and \Fanyrunning. \Fresumereq is ignored by
-running harts.
+\Fanyresumeack, \Fallrunning, and \Fanyrunning.
 
 When halt or resume is requested, a hart must respond in
 less than one second, unless it is unavailable.

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -169,7 +169,7 @@ For every hart, the Debug Module contains 4 conceptual bits of state: halt
 request, resume ack, halt-on-reset request, and hart reset.  (The hart reset
 and halt-on-reset request bits are optional.) These bits all reset to 0. In
 addition there is a resume request signal.  A debugger can write these
-bits/signals for the currently selected harts through \Fhaltreq,
+bits/signals for the currently selected harts through \Fhaltreq, \Fresumereq,
 \Fsetresethaltreq/\Fclrresethaltreq, and \Fhartreset in \Rdmcontrol.  In
 addition the DM receives halted and running signals from each hart.
 

--- a/debugger_implementation.tex
+++ b/debugger_implementation.tex
@@ -46,8 +46,9 @@ process should start at one of the lower {\tt haltsum} registers.
 \section{Halting} \label{deb:halt}
 
 To halt one or more harts, the debugger selects them, sets \Fhaltreq, and then
-waits for \Fallhalted to indicate the harts are halted before clearing
-\Fhaltreq to 0.
+waits for \Fallhalted to indicate the harts are halted. Then it can clear
+\Fhaltreq to 0, or leave it high to catch a hart that unexpectedly resets while
+halted.
 
 \section{Running}
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -133,25 +133,37 @@
 
 \label{resethaltreq}
 \index{resethaltreq}
-        \Fresethaltreq is an internal bit of per-hart state that cannot be
-        read, but can be written with \Fsetresethaltreq and \Fclrresethaltreq.
+        \Fresethaltreq is an optional internal bit of per-hart state that
+        cannot be read, but can be written with \Fsetresethaltreq and
+        \Fclrresethaltreq.
+
+        \begin{commentary}
+        There is an asymmetry between \Fhaltreq and \Fresumereq. \Fhaltreq is
+        level-sensitive when high, to enable debuggers to halt harts out of
+        reset when \Fresethaltreq is not implemented. \Fresumereq only causes
+        harts to resume exactly once, to avoid race conditions where harts
+        resume and immediately halt again faster than the debugger can clear
+        \Fresumereq.
+        \end{commentary}
 
         <!-- Fields that apply to all selected hart(s) -->
-        <field name="haltreq" bits="31" access="W" reset="-">
-            0: May cancel a halt request for any of the currently selected
-            harts, if those harts haven't halted yet.
+        <field name="haltreq" bits="31" access="R/W" reset="0">
+            Writing 0 may cancel a halt request for any of the currently
+            selected harts, if those are attempting to halt when the write
+            occurs.
 
-            1: Causes the currently selected harts to halt, if they are
-            currently running.
+            While the bit is 1, causes the currently selected harts to halt, if
+            they are running.
 
             Writes apply to the new value of \Fhartsel and \Fhasel.
         </field>
         <field name="resumereq" bits="30" access="W" reset="-">
-            0: May cancel a resume request for any of the currently selected
-            harts, if those harts haven't resumed yet.
+            Writing 0 may cancel a resume request for any of the currently
+            selected harts, if those harts are attempting to resume when the
+            write occurs.
 
-            1: Causes the currently selected harts to resume once, if they are
-            currently halted.
+            Writing 1 causes the currently selected harts to resume once, if
+            they halted when the write occurs.
 
             \Fresumereq is ignored if \Fhaltreq is set.
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -148,13 +148,13 @@
         \end{commentary}
 
         <!-- Fields that apply to all selected hart(s) -->
-        <field name="haltreq" bits="31" access="R/W" reset="0">
-            Writing 0 may cancel a halt request for any of the currently
-            selected harts, if those are attempting to halt when the write
-            occurs.
+        <field name="haltreq" bits="31" access="W" reset="-">
+            Writing 0 clears the halt request bit for all currently selected
+            harts. This may cancel outstanding halt requests for those harts.
 
-            While the bit is 1, causes the currently selected harts to halt, if
-            they are running.
+            Writing 1 sets the halt request bit for all currently selected
+            harts. Running harts will halt whenever their halt request bit is
+            set.
 
             Writes apply to the new value of \Fhartsel and \Fhasel.
         </field>

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -163,7 +163,7 @@
             write occurs.
 
             Writing 1 causes the currently selected harts to resume once, if
-            they halted when the write occurs.
+            they are halted when the write occurs.
 
             \Fresumereq is ignored if \Fhaltreq is set.
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -128,8 +128,9 @@
         \end{commentary}
 
         On any given write, a debugger may only write 1 to at most one of the
-        following bits: \Fhaltreq, \Fresumereq, \Fhartreset, \Fackhavereset,
-        \Fsetresethaltreq, and \Fclrresethaltreq. The others must be written 0.
+        following bits: \Fresumereq, \Fhartreset, \Fackhavereset,
+        \Fsetresethaltreq, and \Fclrresethaltreq.  The others must be written
+        0.
 
 \label{resethaltreq}
 \index{resethaltreq}
@@ -158,7 +159,8 @@
             Writes apply to the new value of \Fhartsel and \Fhasel.
         </field>
         <field name="resumereq" bits="30" access="W" reset="-">
-            Writing 0 may cancel a resume request for any of the currently
+            Writing 0 clears the hart's resume ack signal. It also
+            may cancel a resume request for any of the currently
             selected harts, if those harts are attempting to resume when the
             write occurs.
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -158,14 +158,10 @@
 
             Writes apply to the new value of \Fhartsel and \Fhasel.
         </field>
-        <field name="resumereq" bits="30" access="W" reset="-">
-            Writing 0 clears the hart's resume ack signal. It also
-            may cancel a resume request for any of the currently
-            selected harts, if those harts are attempting to resume when the
-            write occurs.
-
+        <field name="resumereq" bits="30" access="W1" reset="-">
             Writing 1 causes the currently selected harts to resume once, if
-            they are halted when the write occurs.
+            they are halted when the write occurs. It also clears the resume
+            ack bit for those harts.
 
             \Fresumereq is ignored if \Fhaltreq is set.
 


### PR DESCRIPTION
It used to be like this, and then I made it more consistent in 19058ef9,
not realizing that this breaks the possibility of keeping haltreq high
to cause a halt-on-reset.