### PR TITLE
Abstract reg access is independent of run/halt.

### DIFF
--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -26,9 +26,6 @@
         and must support read and write access to all GPRs when the selected hart is halted.
         Debug Modules may optionally support accessing other registers,
         or accessing registers when the hart is running.
-        If this command is
-        supported for a register while the hart is running, it must also
-        be supported for a register while the hart is halted.
         Each individual register (aside from GPRs) may be supported differently
         across read, write, and halt status.
 


### PR DESCRIPTION
This resolves a contradiction in the spec.
Fixes #365.