### PR TITLE
Format quotes correctly.

### DIFF
--- a/dtm.tex
+++ b/dtm.tex
@@ -18,8 +18,8 @@ may be added in future versions of this specification.
 
 An implementation can be compliant with this specification without implementing
 any of this section. In that case it must be advertised as conforming to
-"RISC-V Debug Specification \versionnum, with custom DTM." If the JTAG DTM
+``RISC-V Debug Specification \versionnum, with custom DTM.'' If the JTAG DTM
 described here is implemented, it must be advertised as conforming to the
-"RISC-V Debug Specification \versionnum, with JTAG DTM."
+``RISC-V Debug Specification \versionnum, with JTAG DTM.''
 
 \input{jtagdtm}

--- a/introduction.tex
+++ b/introduction.tex
@@ -57,7 +57,7 @@ of bits in the field are shown below it.
 
 After the graphic follows a table which for each field lists its name,
 description, allowed accesses, and reset value. The allowed accesses are listed
-in Table~\ref{tab:access}. The reset value is either a constant or "Preset."
+in Table~\ref{tab:access}. The reset value is either a constant or ``Preset.''
 The latter means it is an implementation-specific legal value.
 
 Names of registers and their fields are hyperlinks to their definition, and are

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -34,11 +34,11 @@ Unimplemented instructions must select the BYPASS register.
 \subsection{Recommended JTAG Connector}
 
 To make it easy to acquire debug hardware, this spec recommends a connector
-that is compatible with the MIPI-10 .05" connector specification, as described
+that is compatible with the MIPI-10 .05 inch connector specification, as described
 in the MIPI Alliance Recommendation for Debug and Trace Connectors, Version
 1.10.00, 16 March 2011.
 
-The connector is a .05"-spaced, gold-plated male header with .016" thick
+The connector has .05 inch spacing, gold-plated male header with .016 inch thick
 hardened copper or beryllium bronze square posts (SAMTEC FTSH or equivalent).
 Female connectors are compatible $20\mu m$ gold connectors.
 


### PR DESCRIPTION
For inches, apparently the thing to do is spell them out, so I did that.