### PR TITLE
Make haltreq and resumereq proper write-only.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -176,7 +176,7 @@ deasserted. Finally they end up either running or halted, depending on
 
 \section{Run Control} \label{runcontrol}
 
-For every hart, the Debug Module contains 4 conceptual bits of state: halt
+For every hart, the Debug Module tracks 4 conceptual bits of state: halt
 request, resume ack, halt-on-reset request,  and hart reset.
 (The hart reset and halt-on-reset request bits are optional.)
 These bits all reset to 0. A debugger can write them for the currently selected

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -177,24 +177,24 @@ deasserted. Finally they end up either running or halted, depending on
 \section{Run Control} \label{runcontrol}
 
 For every hart, the Debug Module contains 4 conceptual bits of state: halt
-request, resume request, halt-on-reset request,  and hart reset.
+request, resume ack, halt-on-reset request,  and hart reset.
 (The hart reset and halt-on-reset request bits are optional.)
 These bits all reset to 0. A debugger can write them for the currently selected
-harts through \Fhaltreq, \Fresumereq, \Fsetresethaltreq/\Fclrresethaltreq and
-\Fhartreset in \Rdmcontrol, only one of which may be high in any single write.
-In addition the DM receives halted, running, and resume ack signals from each
-hart.
+harts through \Fhaltreq, \Fsetresethaltreq/\Fclrresethaltreq and
+\Fhartreset in \Rdmcontrol.
+In addition the DM receives halted and running signals from each hart.
 
-When a running hart receives a halt request, it responds by halting,
+When a running hart sees its halt request bit high, it responds by halting,
 deasserting its running signal, and asserting its halted signal. The halted
 signals of all selected harts are reflected in the \Fallhalted and \Fanyhalted
-bits. \Fhaltreq is ignored by halted harts.
+bits. Halted harts ignore their halt request bit.
 
 When a halted hart receives a resume request, it responds by resuming, clearing
-its halted signal, and asserting its running signal and resume ack signals. The
-resume ack signal is lowered when the resume request is deasserted.  These
+its halted signal, and asserting its running signal. The DM
+reacts to a hart's running signal going high by setting resume ack for that
+hart. These
 status signals of all selected harts are reflected in \Fallresumeack,
-\Fanyresumeack, \Fallrunning, and \Fanyrunning. \Fresumereq is ignored by
+\Fanyresumeack, \Fallrunning, and \Fanyrunning. Resume requests are ignored by
 running harts.
 
 When halt or resume is requested, a hart must respond in

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -189,10 +189,10 @@ deasserting its running signal, and asserting its halted signal. The halted
 signals of all selected harts are reflected in the \Fallhalted and \Fanyhalted
 bits. Halted harts ignore their halt request bit.
 
-When a halted hart receives a resume request, it responds by resuming, clearing
-its halted signal, and asserting its running signal. The DM
-reacts to a hart's running signal going high by setting resume ack for that
-hart. These
+When a debugger writes 1 to \Fresumereq, each selected hart's resume ack bit is
+cleared and each selected, halted hart is sent a resume request. Harts respond
+by resuming, clearing their halted signal, and asserting their running signal.
+At the end of this process the resume ack bit is cleared.  These
 status signals of all selected harts are reflected in \Fallresumeack,
 \Fanyresumeack, \Fallrunning, and \Fanyrunning. Resume requests are ignored by
 running harts.

--- a/debugger_implementation.tex
+++ b/debugger_implementation.tex
@@ -46,8 +46,9 @@ process should start at one of the lower {\tt haltsum} registers.
 \section{Halting} \label{deb:halt}
 
 To halt one or more harts, the debugger selects them, sets \Fhaltreq, and then
-waits for \Fallhalted to indicate the harts are halted before clearing
-\Fhaltreq to 0.
+waits for \Fallhalted to indicate the harts are halted. Then it can clear
+\Fhaltreq to 0, or leave it high to catch a hart that unexpectedly resets while
+halted.
 
 \section{Running}
 

--- a/debugger_implementation.tex
+++ b/debugger_implementation.tex
@@ -47,8 +47,7 @@ process should start at one of the lower {\tt haltsum} registers.
 
 To halt one or more harts, the debugger selects them, sets \Fhaltreq, and then
 waits for \Fallhalted to indicate the harts are halted. Then it can clear
-\Fhaltreq to 0, or leave it high to catch a hart that unexpectedly resets while
-halted.
+\Fhaltreq to 0, or leave it high to catch a hart that resets while halted.
 
 \section{Running}
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -128,30 +128,29 @@
         \end{commentary}
 
         On any given write, a debugger may only write 1 to at most one of the
-        following bits: \Fhaltreq, \Fresumereq, \Fhartreset, \Fackhavereset,
+        following bits: \Fresumereq, \Fhartreset, \Fackhavereset,
         \Fsetresethaltreq, and \Fclrresethaltreq. The others must be written 0.
 
 \label{resethaltreq}
 \index{resethaltreq}
-        \Fresethaltreq is an internal bit of per-hart state that cannot be
+        \Fresethaltreq is an optional internal bit of per-hart state that cannot be
         read, but can be written with \Fsetresethaltreq and \Fclrresethaltreq.
 
         <!-- Fields that apply to all selected hart(s) -->
         <field name="haltreq" bits="31" access="W" reset="-">
-            0: May cancel a halt request for any of the currently selected
-            harts, if those harts haven't halted yet.
+            Writing 0 clears the halt request bit for all currently selected
+            harts. This may cancel outstanding halt requests for those harts.
 
-            1: Causes the currently selected harts to halt, if they are
-            currently running.
+            Writing 1 sets the halt request bit for all currently selected
+            harts. Running harts will halt whenever their halt request bit is
+            set.
 
             Writes apply to the new value of \Fhartsel and \Fhasel.
         </field>
-        <field name="resumereq" bits="30" access="W" reset="-">
-            0: May cancel a resume request for any of the currently selected
-            harts, if those harts haven't resumed yet.
-
-            1: Causes the currently selected harts to resume once, if they are
-            currently halted.
+        <field name="resumereq" bits="30" access="W1" reset="-">
+            Writing 1 causes the currently selected harts to resume once, if
+            they are halted when the write occurs. It also clears the resume
+            ack bit for those harts.
 
             \Fresumereq is ignored if \Fhaltreq is set.
 


### PR DESCRIPTION
They already mostly were, but then I clarified some stuff and broke
keeping haltreq high during reset, which is the only mechanism to catch
a hart out of reset if optional reselthaltreq isn't implemented.

Also:
* resume ack is cleared by the DM when resumereq is written 1.
* haltreq can be high together with hartreset.

This is the minimal version of #378. It has all the same functionality,
but lacks some of #378's clarifications, which may be making this harder
to review.