### PR TITLE
Add halt groups and external triggers.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -221,7 +221,9 @@ while the hart is selected, or by DM reset.
 
 An optional feature allows a debugger to create halt groups. When any hart in a
 halt group halts all the other harts in that group will quickly halt, even if
-they are currently in the process of resuming.
+they are currently in the process of resuming. Adding a hart to a halt group
+does not automatically halt that hart, even if other harts in the group are
+already halted.
 
 It is also possible to add external triggers to a halt group. External triggers
 are abstract concepts that can signal the DM and/or receive signals from the

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -217,6 +217,31 @@ The hart's halt-on-reset request bit remains set
 until cleared by the debugger writing 1 to \Fclrresethaltreq
 while the hart is selected, or by DM reset.
 
+\section{Halt Groups and External Triggers}
+
+An optional feature allows a debugger to create halt groups. When any hart in a
+halt group halts all the other harts in that group will quickly halt, even if
+they are currently in the process of resuming.
+
+It is also possible to add external triggers to a halt group. External triggers
+are abstract concepts that can signal the DM and/or receive signals from the
+DM.  When an external trigger fires, all harts in its halt group are quickly
+halted. When a hart in a halt group halts, the external triggers in the same
+halt group are notified.
+
+\begin{commentary}
+    External triggers could be used to implement near simultaneous halting of
+    all cores in a system, when not all cores are RISC-V cores.
+\end{commentary}
+
+Halt group 0 is special, and has none of this behavior. Harts in halt group 0
+halt as if halt groups aren't implemented at all.
+
+To near simultaneously resume all harts in a group, the debugger can select all
+the harts, and write 1 to \Fresumereq as described above. An implementation
+must guarantee that all harts in the group halt again as soon as one of them
+halts, even if that hart halts before all harts have resumed.
+
 \section{Abstract Commands} \label{abstractcommands}
 
 The DM supports a set of abstract commands, most of which

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -16,6 +16,9 @@
 \item Allow multiple harts to be halted, resumed, and/or reset at the same time. (Optional)
 \item Allow memory access from a hart's point of view. (Optional)
 \item Allow direct System Bus Access. (Optional)
+\item Group harts. When any hart in the group halts, they all halt. (Optional)
+\item Respond to external triggers by halting each hart in a configured group. (Optional)
+\item Signal an external trigger when a hart in a group halts. (Optional)
 \end{steps}
 
 \begin{steps}{In order to be compliant with this specification an

--- a/introduction.tex
+++ b/introduction.tex
@@ -170,6 +170,9 @@ The debug interface described in this specification supports the following featu
        involving any hart. (Optional)
    \item A RISC-V hart can be halted when a trigger matches the PC,
        read/write address/data, or an instruction opcode. (Optional)
+    \item Harts can be grouped, and harts in the same group will all halt when
+        any of them halts. These groups can also react to or notify external
+        triggers. (Optional)
 \end{enumerate}
 
 This document does not suggest a strategy or implementation for hardware test,

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -72,7 +72,7 @@
 
             1: An {\tt ebreak} instruction was executed. (priority 3)
 
-            2: The Trigger Module caused a breakpoint exception. (priority 4, highest)
+            2: The Trigger Module caused a breakpoint exception. (priority 4)
 
             3: The debugger requested entry to Debug Mode using \Fhaltreq.
             (priority 1)
@@ -81,6 +81,9 @@
 
             5: The hart halted directly out of reset due to \Fresethaltreq. It
             is also acceptable to report 3 when this happens. (priority 2)
+
+            6: The hart halted because it's part of a halt group. (priority 5,
+            highest) Harts may report 3 for this cause instead.
 
             Other values are reserved for future use.
         </field>

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -540,6 +540,46 @@
         <field name="data" bits="31:0" access="R/W" reset="0" />
     </register>
 
+    <register name="Advanced" short="advanced" address="0x32">
+        <field name="0" bits="31:11" access="R" reset="0" />
+        <field name="exttrigger" bits="10:7" access="WARL" reset="0">
+            This field contains the currently selected external trigger.
+
+            If a non-existant trigger value is written here, the hardware will
+            change it to a valid one or 0 if no external triggers exist.
+        </field>
+        <field name="haltgroup" bits="6:2" access="WARL" reset="0">
+            When \Fhgselect is 0, contains the halt group of the hart
+            specified by \Fhartsel.
+
+            When \Fhgselect is 1, contains the halt group of the external
+            trigger selected by \Fexttrigger.
+
+            Writes only have an effect if \Fhgwrite is also written 1.
+
+            An implementation may tie any number of upper bits in this field to
+            0. If halt groups aren't implemented, then this entire field
+            is 0.
+        </field>
+        <field name="hgwrite" bits="1" access="W" reset="-">
+            When \Fhgselect is 0, writing 1 changes the halt group of all
+            selected harts to the value written to \Fhaltgroup.
+
+            When \Fhgselect is 1, writing 1 changes the halt group of the
+            external trigger selected by \Fexttrigger to the value written to
+            \Fhaltgroup.
+
+            Writing 0 has no effect.
+        </field>
+        <field name="hgselect" bits="0" access="WARL" reset="0">
+            0: Operate on harts.
+
+            1: Operate on external triggers.
+
+            If there are no external triggers, this field must be tied to 0.
+        </field>
+    </register>
+
     <register name="Halt Summary 0" short="haltsum0" address="0x40">
         Each bit in this read-only register indicates whether one specific hart
         is halted or not. Unavailable/nonexistent harts are not considered to

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -542,8 +542,7 @@
 
     <register name="Debug Module Control and Status 2" short="dmcs2" address="0x32">
         This register contains DM control and status bits that didn't easily
-        fit in \Rdmcontrol and \Rdmstatus, and are only likely to be
-        implemented in larger systems.
+        fit in \Rdmcontrol and \Rdmstatus. All are optional.
 
         <field name="0" bits="31:11" access="R" reset="0" />
         <field name="exttrigger" bits="10:7" access="WARL" reset="0">

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -545,7 +545,7 @@
         <field name="exttrigger" bits="10:7" access="WARL" reset="0">
             This field contains the currently selected external trigger.
 
-            If a non-existant trigger value is written here, the hardware will
+            If a non-existent trigger value is written here, the hardware will
             change it to a valid one or 0 if no external triggers exist.
         </field>
         <field name="haltgroup" bits="6:2" access="WARL" reset="0">

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -540,7 +540,11 @@
         <field name="data" bits="31:0" access="R/W" reset="0" />
     </register>
 
-    <register name="Advanced" short="advanced" address="0x32">
+    <register name="Debug Module Control and Status 2" short="dmcs2" address="0x32">
+        This register contains DM control and status bits that didn't easily
+        fit in \Rdmcontrol and \Rdmstatus, and are only likely to be
+        implemented in larger systems.
+
         <field name="0" bits="31:11" access="R" reset="0" />
         <field name="exttrigger" bits="10:7" access="WARL" reset="0">
             This field contains the currently selected external trigger.


### PR DESCRIPTION
This allows a group of harts to simultaneously halt when any of them
hits a breakpoint, or even when some other event occurs in the system.