### PR TITLE
Abstract memory accesses use the low bits of arg0.

### DIFF
--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -197,11 +197,12 @@
         </field>
         <field name="0" bits="18:17" />
         <field name="write" bits="16">
-            0: Copy data from the memory location specified in {\tt arg1} into {\tt arg0} portion
-               of {\tt data}.
+            0: Copy data from the memory location specified in {\tt arg1} into
+            the low bits of {\tt arg0}. Any remaining bits of {\tt arg0} now
+            have an undefined value.
 
-            1: Copy data from {\tt arg0} portion of {\tt data} into the
-               memory location specified in {\tt arg1}.
+            1: Copy data from the low bits of {\tt arg0} into the memory
+            location specified in {\tt arg1}.
         </field>
         <field name="target-specific" bits="15:14">
             These bits are reserved for target-specific uses.


### PR DESCRIPTION
Hopefully clarifies #427.