### PR TITLE
All trigger registers are optional

### DIFF
--- a/trigger.tex
+++ b/trigger.tex
@@ -10,14 +10,16 @@ Trigger Module is broken out as a separate piece that can be implemented
 separately.
 
 A hart can be compliant with this specification without implementing any
-trigger functionality at all, but if it is implemented then it must conform
-to this section.
+trigger functionality at all, but if it is implemented then it must conform to
+this section. If triggers aren't implemented, the CSRs may not exist at all and
+accessing them results in an illegal instruction exception.
 
 Triggers do not fire while in Debug Mode.
 
 \begin{steps}{Each trigger may support a variety of features. A debugger can
     build a list of all triggers and their features as follows:}
-\item Write 0 to \Rtselect.
+\item Write 0 to \Rtselect. If this results in an illegal instruction
+    exception, then there are no triggers implemented.
 \item Read back \Rtselect and check that it contains the written value. If not,
     exit the loop.
 \item Read \Rtinfo.

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -30,8 +30,8 @@
 
     <register name="Trigger Select" short="tselect" address="0x7a0">
         This register determines which trigger is accessible through the other
-        trigger registers. The set of accessible triggers must start at 0, and
-        be contiguous.
+        trigger registers. It is optional if no triggers are implemented.  The
+        set of accessible triggers must start at 0, and be contiguous.
 
         Writes of values greater than or equal to the number of supported
         triggers may result in a different value in this register than what was
@@ -45,6 +45,8 @@
     </register>
 
     <register name="Trigger Data 1" short="tdata1" address="0x7a1">
+        This register is optional if no triggers are implemented.
+
         <field name="type" bits="XLEN-1:XLEN-4" access="R/W" reset="Preset">
             0: There is no trigger at this \Rtselect.
 
@@ -85,20 +87,26 @@
     </register>
 
     <register name="Trigger Data 2" short="tdata2" address="0x7a2">
-        Trigger-specific data.
+        Trigger-specific data. It is optional if no implemented triggers use
+        it.
 
         If XLEN is less than DXLEN, writes to this register are sign-extended.
         <field name="data" bits="XLEN-1:0" access="R/W" reset="Preset" />
     </register>
 
     <register name="Trigger Data 3" short="tdata3" address="0x7a3">
-        Trigger-specific data.
+        Trigger-specific data. It is optional if no implemented triggers use
+        it.
 
         If XLEN is less than DXLEN, writes to this register are sign-extended.
         <field name="data" bits="XLEN-1:0" access="R/W" reset="Preset" />
     </register>
 
     <register name="Trigger Info" short="tinfo" address="0x7a4">
+        This register is optional if no triggers are implemented, or if \Ftype
+        is not writable. In this case the debugger can read the only supported
+        type from \Rtdataone.
+
         <field name="0" bits="XLEN-1:16" access="R" reset="0" />
         <field name="info" bits="15:0" access="R" reset="Preset">
             One bit for each possible \Ftype enumerated in \Rtdataone. Bit N
@@ -107,11 +115,6 @@
 
             If the currently selected trigger doesn't exist, this field
             contains 1.
-
-            If \Ftype is not writable, this register may be unimplemented, in
-            which case reading it causes an illegal instruction exception. In
-            this case the debugger can read the only supported type from
-            \Rtdataone.
         </field>
     </register>
 
@@ -142,7 +145,7 @@
     </register>
 
     <register name="Machine Context" short="mcontext" address="0x7a8">
-        This register is only writable in M mode and Debug Mode.
+        This optional register is only writable in M mode and Debug Mode.
 
         <field name="mcontext" bits="XLEN-1:0" access="R/W" reset="0">
             Machine mode software can write a context number to this register,
@@ -156,7 +159,7 @@
     </register>
 
     <register name="Supervisor Context" short="scontext" address="0x7aa">
-        This register is only writable in S mode, M mode and Debug Mode.
+        This optional register is only writable in S mode, M mode and Debug Mode.
 
         <field name="data" bits="XLEN-1:0" access="R/W" reset="0">
             Supervisor mode software can write a context number to this


### PR DESCRIPTION
See #422. This might break software that's not ready for the
possibility, but I believe the privilege spec is already clear that the
Debug CSRs are optional.