### PR TITLE
When extending IR, BYPASS still is all ones.

### DIFF
--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -23,8 +23,9 @@ When the TAP is reset, IR must default to
 00001, selecting the IDCODE instruction. A full list of JTAG registers along
 with their encoding is in Table~\ref{table:jtag_registers}.
 If the IR actually has more than 5 bits, then the encodings in
-Table~\ref{table:jtag_registers} should be extended with 0's in their
-most significant bits.
+Table~\ref{table:jtag_registers} should be extended with 0's in their most
+significant bits, except for the 0x1f encoding of BYPASS, which must be
+extended with 1's in the most significant bits.
 The only regular JTAG registers a debugger might use are BYPASS and IDCODE, but this
 specification leaves IR space for many other standard JTAG instructions.
 Unimplemented instructions must select the BYPASS register.


### PR DESCRIPTION
See #436. Does this change need to go in 0.13 as well?