### PR TITLE
sberror and sbbusyerror don't both have to be non-zero to prevent access

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -810,7 +810,7 @@
         the read access is less than the width of {\tt sbdata}, the contents of
         the remaining high bits may take on any value.
 
-        If \Fsberror or \Fsbbusyerror both aren't 0 then accesses do nothing.
+        If either \Fsberror or \Fsbbusyerror isn't 0 then accesses do nothing.
 
         If the bus master is busy then accesses set \Fsbbusyerror, and don't do
         anything else.


### PR DESCRIPTION
The definition of sberror says:
> While this field is non-zero, no more system bus accesses can be initiated by the Debug Module.

and sbbusyerror says:
> While this field is set, no more system bus accesses can be initiated by the Debug Module.

This means that either one being non-zero prevents further access.  Section 3.14.24 shouldn't say that no access takes place only if **both** are non-zero.