### PR TITLE
Fully qualify register/field macro names.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ REGISTERS_TEX += dm_registers.tex
 REGISTERS_TEX += sample_registers.tex
 REGISTERS_TEX += abstract_commands.tex
 REGISTERS_TEX += sw_registers.tex
+REGISTERS_TEX += serial.tex
 
 REGISTERS_CHISEL += dm_registers.scala
 REGISTERS_CHISEL += abstract_commands.scala
@@ -67,6 +68,7 @@ debug_defines.h:	$(REGISTERS_TEX:.tex=.h)
 
 %.tex %.h: xml/%.xml registers.py
 	./registers.py --custom --definitions $@.inc --cheader $(basename $@).h $< > $@
+
 
 %.scala: xml/%.xml registers.py
 	./registers.py --chisel $(basename $@).scala $< > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ REGISTERS_TEX += dm_registers.tex
 REGISTERS_TEX += sample_registers.tex
 REGISTERS_TEX += abstract_commands.tex
 REGISTERS_TEX += sw_registers.tex
-REGISTERS_TEX += serial.tex
 
 REGISTERS_CHISEL += dm_registers.scala
 REGISTERS_CHISEL += abstract_commands.scala
@@ -68,7 +67,6 @@ debug_defines.h:	$(REGISTERS_TEX:.tex=.h)
 
 %.tex %.h: xml/%.xml registers.py
 	./registers.py --custom --definitions $@.inc --cheader $(basename $@).h $< > $@
-
 
 %.scala: xml/%.xml registers.py
 	./registers.py --chisel $(basename $@).scala $< > /dev/null

--- a/core_debug.tex
+++ b/core_debug.tex
@@ -17,20 +17,20 @@ external debugging. How Debug Mode is implemented is not specified here.
 \begin{steps}{When executing code from the optional Program Buffer, the hart
     stays in Debug Mode and the following apply:}
 \item All operations are executed at machine mode privilege level, except that
-    \Fmprv in \Rmstatus may be ignored according to \Fmprven.
+    \FcsrMcontrolMprv in \Rmstatus may be ignored according to \FcsrDcsrMprven.
 \item All interrupts (including NMI) are masked.
 \item Exceptions don't update any registers.  That includes {\tt cause}, {\tt
     epc}, {\tt tval}, {\tt dpc}, and \Rmstatus. They do end execution of the
     Program Buffer.
 \item No action is taken if a trigger matches.
-\item Counters may be stopped, depending on \Fstopcount in \Rdcsr.
-\item Timers may be stopped, depending on \Fstoptime in \Rdcsr.
+\item Counters may be stopped, depending on \FcsrDcsrStopcount in \RcsrDcsr.
+\item Timers may be stopped, depending on \FcsrDcsrStoptime in \RcsrDcsr.
 \item The {\tt wfi} instruction acts as a {\tt nop}.
 \item Almost all instructions that change the privilege level have undefined
     behavior.  This includes {\tt ecall}, {\tt mret}, {\tt sret},
     and {\tt uret}.  (To change the privilege level, the debugger can write
-    \Fprv in \Rdcsr). The only exception is {\tt ebreak}. When that is executed
-    in Debug Mode, it halts the hart again but without updating \Rdpc or \Rdcsr.
+    \FcsrDcsrPrv in \RcsrDcsr). The only exception is {\tt ebreak}. When that is executed
+    in Debug Mode, it halts the hart again but without updating \RcsrDpc or \RcsrDcsr.
 \item \label{fence} Completing Program Buffer execution is considered output for the purpose
     of {\tt fence} instructions.
 \item All control transfer instructions may act as illegal instructions if
@@ -47,9 +47,9 @@ external debugging. How Debug Mode is implemented is not specified here.
 \end{steps}
 
 \begin{commentary}
-    In general, the debugger is expected to be able to simulate all the effects of \Fmprv.
-    The exception is the case of Sv32 systems, which need \Fmprv functionality in order to access
-    34-bit physical addresses. Other systems are likely to tie \Fmprven to 0.
+    In general, the debugger is expected to be able to simulate all the effects of \FcsrMcontrolMprv.
+    The exception is the case of Sv32 systems, which need \FcsrMcontrolMprv functionality in order to access
+    34-bit physical addresses. Other systems are likely to tie \FcsrDcsrMprven to 0.
 \end{commentary}
 
 \section{Load-Reserved/Store-Conditional Instructions}
@@ -79,14 +79,14 @@ Mode.
 \section{Single Step}
 
 A debugger can cause a halted hart to execute a single instruction and then
-re-enter Debug Mode by setting \Fstep before setting \Fresumereq.
+re-enter Debug Mode by setting \FcsrDcsrStep before setting \FdmDmcontrolResumereq.
 
 If executing or fetching that instruction causes an exception, Debug Mode is
 re-entered immediately after the PC is changed to the exception handler and the
 appropriate {\tt tval} and {\tt cause} registers are updated.
 
 If executing or fetching the instruction causes a trigger to fire, Debug Mode
-is re-entered immediately after that trigger has fired. In that case \Fcause is
+is re-entered immediately after that trigger has fired. In that case \FcsrDcsrCause is
 set to 2 (trigger) instead of 4 (single step).  Whether the instruction is
 executed or not depends on the specific configuration of the trigger.
 
@@ -111,8 +111,8 @@ executed.
 To return from Debug Mode, a new instruction is defined: {\tt dret}. It has an
 encoding of 0x7b200073. On harts which support this instruction,
 executing {\tt dret} in Debug Mode changes \Rpc to the value
-stored in \Rdpc. The current privilege level is changed to that specified by
-\Fprv in \Rdcsr. The hart is no longer in debug mode.
+stored in \RcsrDpc. The current privilege level is changed to that specified by
+\FcsrDcsrPrv in \RcsrDcsr. The hart is no longer in debug mode.
 
 Executing {\tt dret} outside of Debug Mode causes an illegal instruction exception.
 

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -32,8 +32,8 @@
         \item Implement abstract access to all registers that are visible to
             software running on the hart including all the registers that are
             present on the hart and listed in Table~\ref{tab:regno}.
-        \item Implement abstract access to at least all GPRs, \Rdcsr, and
-            \Rdpc, and advertise the implementation as conforming to the
+        \item Implement abstract access to at least all GPRs, \RcsrDcsr, and
+            \RcsrDpc, and advertise the implementation as conforming to the
             ``Minimal RISC-V Debug Specification \versionnum'', instead of the
             ``RISC-V Debug Specification \versionnum''.
     \end{steps}
@@ -54,14 +54,14 @@ operations.  The bottom of the address space is
 used for the first (and usually only) DM. Extra space can be used for custom
 debug devices, other cores, additional DMs, etc. If there are additional DMs
 on this DMI, the base address of the next DM in the DMI address space is given
-in \Rnextdm.
+in \RdmNextdm.
 
 
 The Debug Module is controlled via register accesses to its DMI address space.
 
 \section{Reset Control} \label{reset}
 
-The Debug Module controls a global reset signal, \Fndmreset
+The Debug Module controls a global reset signal, \FdmDmcontrolNdmreset
 (non-debug module reset),
 which can reset, or hold in reset, every component in the platform,
 except for the Debug Module and Debug Transport Modules.
@@ -69,40 +69,40 @@ Exactly what is affected by this reset is implementation dependent, as long as
 it is possible to debug programs from the first instruction executed.
 The Debug Module's own state and registers should only be
 reset at power-up and while
-\Fdmactive in \Rdmcontrol is 0.
+\FdmDmcontrolDmactive in \RdmDmcontrol is 0.
 The halt state of harts should be
-maintained across system reset provided that \Fdmactive is 1,
+maintained across system reset provided that \FdmDmcontrolDmactive is 1,
 although trigger CSRs may be cleared.
 
 Due to clock and power domain crossing issues,
 it may not be possible to perform arbitrary DMI accesses across
 system reset.
-While \Fndmreset or any external reset is asserted, the only supported DM
-operations are reading and writing \Rdmcontrol. The behavior of other accesses
+While \FdmDmcontrolNdmreset or any external reset is asserted, the only supported DM
+operations are reading and writing \RdmDmcontrol. The behavior of other accesses
 is undefined.
 
-There is no requirement on the duration of the assertion of \Fndmreset.
-The implementation must ensure that a write of \Fndmreset to 1 followed by
-a write of \Fndmreset to 0 triggers system reset. The system may take
-an arbitrarily long time to come out of reset, as reported by \Fallunavail,
-\Fanyunavail.
+There is no requirement on the duration of the assertion of \FdmDmcontrolNdmreset.
+The implementation must ensure that a write of \FdmDmcontrolNdmreset to 1 followed by
+a write of \FdmDmcontrolNdmreset to 0 triggers system reset. The system may take
+an arbitrarily long time to come out of reset, as reported by \FdmDmstatusAllunavail,
+\FdmDmstatusAnyunavail.
 
 Individual harts (or several at once) can be reset by selecting them, setting
-and then clearing \Fhartreset. In this case an implementation may reset more
+and then clearing \FdmDmcontrolHartreset. In this case an implementation may reset more
 harts than just the ones that are selected. The debugger can discover which
-other harts are reset (if any) by selecting them and checking \Fanyhavereset
-and \Fallhavereset.
+other harts are reset (if any) by selecting them and checking \FdmDmstatusAnyhavereset
+and \FdmDmstatusAllhavereset.
 
 When harts have been reset, they must set a sticky {\tt havereset} state bit.
 The conceptual {\tt havereset} state bits can be read for selected harts in
-\Fanyhavereset and \Fallhavereset in \Rdmstatus.
+\FdmDmstatusAnyhavereset and \FdmDmstatusAllhavereset in \RdmDmstatus.
 These bits must be set regardless of the cause of the reset.
 The {\tt havereset} bits for the selected harts
-can be cleared by writing 1 to \Fackhavereset in \Rdmcontrol.
+can be cleared by writing 1 to \FdmDmcontrolAckhavereset in \RdmDmcontrol.
 The {\tt havereset} bits may or may not be cleared
-when \Fdmactive is low.
+when \FdmDmcontrolDmactive is low.
 
-When a hart comes out of reset and \Fhaltreq or \Fresethaltreq are set, the
+When a hart comes out of reset and \FdmDmcontrolHaltreq or \Fresethaltreq are set, the
 hart will immediately enter Debug Mode. Otherwise it will execute normally.
 
 \section{Selecting Harts} \label{selectingharts}
@@ -114,7 +114,7 @@ commands are specific to that hart.
 To enumerate all the harts, a debugger must first determine {\tt HARTSELLEN}
 by writing  all ones to \Fhartsel (assuming the maximum size) and reading back
 the value to see which bits were actually set.  Then it selects each hart
-starting from 0 until either \Fanynonexistent in \Rdmstatus is 1, or the
+starting from 0 until either \FdmDmstatusAnynonexistent in \RdmDmstatus is 1, or the
 highest index (depending on {\tt HARTSELLEN}) is reached.
 
 The debugger can discover the mapping between hart indices and
@@ -135,13 +135,13 @@ the hart with index $n$. If the bit is 1 then the hart is selected.  Usually a D
 will have a Hart Array Mask register exactly wide enough to select all the
 harts it supports, but it's allowed to tie any of these bits to 0.
 
-The debugger can set bits in the hart array mask register using \Rhawindowsel
-and \Rhawindow, then apply actions to all selected harts by setting \Fhasel. If
+The debugger can set bits in the hart array mask register using \RdmHawindowsel
+and \RdmHawindow, then apply actions to all selected harts by setting \FdmDmcontrolHasel. If
 this feature is supported, multiple harts can be halted, resumed, and reset
 simultaneously. The state of the hart array mask register is not affected by
-setting or clearing \Fhasel.
+setting or clearing \FdmDmcontrolHasel.
 
-Only the actions initiated by \Rdmcontrol can apply to multiple harts
+Only the actions initiated by \RdmDmcontrol can apply to multiple harts
 at once, Abstract Commands apply only to the hart selected by
 \Fhartsel.
 
@@ -149,9 +149,10 @@ at once, Abstract Commands apply only to the hart selected by
 
 Every hart that can be selected is in exactly one of the following four states:
 non-existent, unavailable, running, or halted. Which state
-the selected harts are in is reflected by \Fallnonexistent, \Fanynonexistent,
-\Fallunavail, \Fanyunavail, \Fallrunning, \Fanyrunning, \Fallhalted, and
-\Fanyhalted.
+the selected harts are in is reflected by \FdmDmstatusAllnonexistent,
+\FdmDmstatusAnynonexistent, \FdmDmstatusAllunavail, \FdmDmstatusAnyunavail,
+\FdmDmstatusAllrunning, \FdmDmstatusAnyrunning, \FdmDmstatusAllhalted, and
+\FdmDmstatusAnyhalted.
 
 Harts are nonexistent if they will never be part of this system, no matter how
 long a user waits. E.g.\ in a simple single-hart system only one hart exists,
@@ -179,7 +180,7 @@ Which states a hart that is reset goes through is implementation dependent.
 Harts may be unavailable while reset is asserted, and some time after reset is
 deasserted. They might transition to running for some time after reset is
 deasserted. Finally they end up either running or halted, depending on
-\Fhaltreq and \Fresethaltreq.
+\FdmDmcontrolHaltreq and \Fresethaltreq.
 
 \section{Run Control} \label{runcontrol}
 
@@ -188,24 +189,24 @@ request, resume ack, halt-on-reset request,  and hart reset.
 (The hart reset and halt-on-reset request bits are optional.)
 These 4 bits reset to 0, except for resume ack, which may reset to either 0 or 1.
 The DM receives halted, running, and havereset signals from each hart.
-The debugger can observe the state of resume ack in \Fallresumeack and
-\Fanyresumeack, and the state of halted, running, and havereset signals
-in \Fallhalted, \Fanyhalted, \Fallrunning, \Fanyrunning, \Fallhavereset,
-and \Fanyhavereset. The state of the other bits cannot be observed directly.
+The debugger can observe the state of resume ack in \FdmDmstatusAllresumeack and
+\FdmDmstatusAnyresumeack, and the state of halted, running, and havereset signals
+in \FdmDmstatusAllhalted, \FdmDmstatusAnyhalted, \FdmDmstatusAllrunning, \FdmDmstatusAnyrunning, \FdmDmstatusAllhavereset,
+and \FdmDmstatusAnyhavereset. The state of the other bits cannot be observed directly.
 
-When a debugger writes 1 to \Fhaltreq, each selected hart's halt request bit is
+When a debugger writes 1 to \FdmDmcontrolHaltreq, each selected hart's halt request bit is
 set.
 When a running hart, or a hart just coming out of reset, sees its halt request
 bit high, it responds by halting, deasserting its running signal, and asserting
 its halted signal.
 Halted harts ignore their halt request bit.
 
-When a debugger writes 1 to \Fresumereq, each selected hart's resume ack bit is
+When a debugger writes 1 to \FdmDmcontrolResumereq, each selected hart's resume ack bit is
 cleared and each selected, halted hart is sent a resume request. Harts respond
 by resuming, clearing their halted signal, and asserting their running signal.
 At the end of this process the resume ack bit is set.  These
-status signals of all selected harts are reflected in \Fallresumeack,
-\Fanyresumeack, \Fallrunning, and \Fanyrunning. Resume requests are ignored by
+status signals of all selected harts are reflected in \FdmDmstatusAllresumeack,
+\FdmDmstatusAnyresumeack, \FdmDmstatusAllrunning, and \FdmDmstatusAnyrunning. Resume requests are ignored by
 running harts.
 
 When halt or resume is requested, a hart must respond in
@@ -214,15 +215,15 @@ less than one second, unless it is unavailable.
 clock cycles will be a more typical latency).
 
 The DM can implement optional halt-on-reset bits for each hart,
-which it indicates by setting \Fhasresethaltreq to 1.
-This means the DM implements the \Fsetresethaltreq and \Fclrresethaltreq bits.
-Writing 1 to \Fsetresethaltreq sets the halt-on-reset request bit for each
+which it indicates by setting \FdmDmstatusHasresethaltreq to 1.
+This means the DM implements the \FdmDmcontrolSetresethaltreq and \FdmDmcontrolClrresethaltreq bits.
+Writing 1 to \FdmDmcontrolSetresethaltreq sets the halt-on-reset request bit for each
 selected hart.
 When a hart's halt-on-reset request bit is set, the hart will immediately enter
 debug mode on the next deassertion of its reset. This is true regardless of
 the reset's cause.
 The hart's halt-on-reset request bit remains set
-until cleared by the debugger writing 1 to \Fclrresethaltreq
+until cleared by the debugger writing 1 to \FdmDmcontrolClrresethaltreq
 while the hart is selected, or by DM reset.
 
 \section{Halt Groups and External Triggers}
@@ -248,7 +249,7 @@ Halt group 0 is special, and has none of this behavior. Harts in halt group 0
 halt as if halt groups aren't implemented at all.
 
 To near simultaneously resume all harts in a group, the debugger can select all
-the harts, and write 1 to \Fresumereq as described above. An implementation
+the harts, and write 1 to \FdmDmcontrolResumereq as described above. An implementation
 must guarantee that all harts in the group halt again as soon as one of them
 halts, even if that hart halts before all harts have resumed.
 
@@ -260,9 +261,9 @@ be able to perform
 some abstract commands even when the selected hart is not halted.
 Debuggers can only determine which abstract commands
 are supported by a given hart in a given state by attempting them
-and then looking at \Fcmderr in \Rabstractcs to see if they were successful.
+and then looking at \FdmAbstractcsCmderr in \RdmAbstractcs to see if they were successful.
 Commands may be supported with some options set, but not with other options
-set. If a command has unsupported options set, the DM must set \Fcmderr to 2
+set. If a command has unsupported options set, the DM must set \FdmAbstractcsCmderr to 2
 (not supported).
 
 \begin{commentary}
@@ -271,16 +272,16 @@ set. If a command has unsupported options set, the DM must set \Fcmderr to 2
     case, the command will return ``not supported.''
 \end{commentary}
 
-Debuggers execute abstract commands by writing them to \Rcommand.  They
-can determine whether an abstract command is complete by reading \Fbusy in
-\Rabstractcs. After completion, \Fcmderr indicates whether the command was
+Debuggers execute abstract commands by writing them to \RdmCommand.  They
+can determine whether an abstract command is complete by reading \FdmAbstractcsBusy in
+\RdmAbstractcs. After completion, \FdmAbstractcsCmderr indicates whether the command was
 successful or not. Commands may fail because a hart is not halted, not running,
 unavailable, or because they encounter an error during execution.
 
 If the command takes arguments, the debugger
-must write them to the {\tt data} registers before writing to \Rcommand. If a
+must write them to the {\tt data} registers before writing to \RdmCommand. If a
 command returns results, the Debug Module must ensure they are placed
-in the {\tt data} registers before \Fbusy is cleared.
+in the {\tt data} registers before \FdmAbstractcsBusy is cleared.
 Which {\tt data} registers are used for the arguments is
 described in Table~\ref{tab:datareg}.  In all cases the least-significant word
 is placed in the lowest-numbered {\tt data} register. The argument width
@@ -295,11 +296,11 @@ specified.
         \hline
         Argument Width & arg0/return value & arg1 & arg2 \\
         \hline
-        32 & \Rdatazero & {\tt data1} & {\tt data2} \\
+        32 & \RdmDataZero & {\tt data1} & {\tt data2} \\
         \hline
-        64 & \Rdatazero, {\tt data1} & {\tt data2}, {\tt data3} & {\tt data4}, {\tt data5} \\
+        64 & \RdmDataZero, {\tt data1} & {\tt data2}, {\tt data3} & {\tt data4}, {\tt data5} \\
         \hline
-        128 & \Rdatazero--{\tt data3} & {\tt data4}--{\tt data7} & {\tt data8}--{\tt data11} \\
+        128 & \RdmDataZero--{\tt data3} & {\tt data4}--{\tt data7} & {\tt data8}--{\tt data11} \\
         \hline
     \end{tabulary}
 \end{table}
@@ -311,45 +312,45 @@ specified.
     the target and commands succeed, which allows for maximum throughput. If
     there is a failure, the interface ensures that no commands execute after
     the failing one.  To discover which command failed, the debugger has to
-    look at the state of the DM (e.g.\ contents of \Rdatazero) or hart (e.g.\ 
+    look at the state of the DM (e.g.\ contents of \RdmDataZero) or hart (e.g.\ 
     contents of a register modified by a Program Buffer program) to determine
     which one failed.
 \end{commentary}
 
-Before starting an abstract command, a debugger must ensure that \Fhaltreq,
-\Fresumereq, and \Fackhavereset are all 0.
+Before starting an abstract command, a debugger must ensure that \FdmDmcontrolHaltreq,
+\FdmDmcontrolResumereq, and \FdmDmcontrolAckhavereset are all 0.
 
-While an abstract command is executing (\Fbusy in \Rabstractcs is high), a
-debugger must not change \Fhartsel, and must not write 1 to \Fhaltreq,
-\Fresumereq, \Fackhavereset, \Fsetresethaltreq, or \Fclrresethaltreq.
+While an abstract command is executing (\FdmAbstractcsBusy in \RdmAbstractcs is high), a
+debugger must not change \Fhartsel, and must not write 1 to \FdmDmcontrolHaltreq,
+\FdmDmcontrolResumereq, \FdmDmcontrolAckhavereset, \FdmDmcontrolSetresethaltreq, or \FdmDmcontrolClrresethaltreq.
 
 If an abstract command does not complete in the expected time and appears to be
 hung, the following procedure can be attempted to abort the command: First the
-debugger resets the hart (using \Fhartreset or \Fndmreset), and then it resets
-the Debug Module (using \Fdmactive).
+debugger resets the hart (using \FdmDmcontrolHartreset or \FdmDmcontrolNdmreset), and then it resets
+the Debug Module (using \FdmDmcontrolDmactive).
 
 If an abstract command is started while the selected hart is unavailable or if
 a hart becomes unavailable while executing an abstract command, then the
-Debug Module may terminate the abstract command, setting \Fbusy low, and
-\Fcmderr to 4 (halt/resume). Alternatively, the command could just appear to be
-hung (\Fbusy never goes low).
+Debug Module may terminate the abstract command, setting \FdmAbstractcsBusy low, and
+\FdmAbstractcsCmderr to 4 (halt/resume). Alternatively, the command could just appear to be
+hung (\FdmAbstractcsBusy never goes low).
 
 \subsection{Abstract Command Listing}
 
 This section describes each of the different abstract commands
 and how their fields should be interpreted when
-they are written to \Rcommand.
+they are written to \RdmCommand.
 
-Each abstract command is a 32-bit value. The top 8 bits contain \Fcmdtype which
+Each abstract command is a 32-bit value. The top 8 bits contain \FdmCommandCmdtype which
 determines the kind of command. Table~\ref{tab:cmdtype} lists all commands.
 
 \begin{table}[htp]
     \centering
-    \caption{Meaning of \Fcmdtype}
+    \caption{Meaning of \FdmCommandCmdtype}
     \label{tab:cmdtype}
     \begin{tabulary}{\textwidth}{|r|l|l|l|}
         \hline
-        \Fcmdtype & Command & Page \\
+        \FdmCommandCmdtype & Command & Page \\
         \hline
         0 & Access Register Command & \pageref{access register} \\
         \hline
@@ -372,15 +373,15 @@ only may choose to omit the Program Buffer.
 
 A debugger can write a small program to the Program Buffer, and then
 execute it exactly once with the Access Register Abstract Command,
-setting the \Fpostexec bit in \Rcommand.
+setting the \FacAccessregisterPostexec bit in \RdmCommand.
 The debugger can write whatever program it likes (including jumps out of the
 Program Buffer), but the program must end with
 {\tt ebreak} or {\tt c.ebreak}. An implementation may support
 an implied {\tt ebreak} that is executed when a hart runs off the end of the
-Program Buffer. This is indicated by \Fimpebreak. With this feature, a Program
+Program Buffer. This is indicated by \FdmDmstatusImpebreak. With this feature, a Program
 Buffer of just 2 32-bit words can offer efficient debugging.
 
-If \Fprogbufsize is 1, \Fimpebreak must be 1. It is possible that the Program
+If \FdmAbstractcsProgbufsize is 1, \FdmDmstatusImpebreak must be 1. It is possible that the Program
 Buffer can hold only one 32- or 16-bit instruction, so the debugger must only
 write a single instruction in this case, regardless of its size.
 This instruction can be a 32-bit
@@ -397,17 +398,17 @@ compressed {\tt nop} in the upper 16 bits.
 While these programs are executed, the hart does not leave Debug Mode (see
 Section~\ref{debugmode}).  If an exception is encountered during execution of
 the Program Buffer, no more instructions are executed, the hart remains in Debug
-Mode, and \Fcmderr is set to 3 ({\tt exception error}).  If the debugger
+Mode, and \FdmAbstractcsCmderr is set to 3 ({\tt exception error}).  If the debugger
 executes a program that doesn't terminate with an {\tt ebreak} instruction, the
 hart will remain in Debug Mode and the debugger will lose control of the hart.
 
-Executing the Program Buffer may clobber \Rdpc. If that is the case, it must be
-possible to read/write \Rdpc using an abstract command with \Fpostexec not set.
-The debugger must attempt to save \Rdpc between halting and
-executing a Program Buffer, and then restore \Rdpc before leaving Debug Mode.
+Executing the Program Buffer may clobber \RcsrDpc. If that is the case, it must be
+possible to read/write \RcsrDpc using an abstract command with \FacAccessregisterPostexec not set.
+The debugger must attempt to save \RcsrDpc between halting and
+executing a Program Buffer, and then restore \RcsrDpc before leaving Debug Mode.
 
 \begin{commentary}
-    Allowing Program Buffer execution to clobber \Rdpc allows for direct
+    Allowing Program Buffer execution to clobber \RcsrDpc allows for direct
     implementations that don't have a separate PC register, and do need to use
     the PC when executing the Program Buffer.
 \end{commentary}
@@ -422,8 +423,8 @@ If so, the debugger has more flexibility in what it can do with the program buff
 
 Figure~\ref{fig:abstract_sm} shows a conceptual view of the states
 passed through by a hart during run/halt debugging as influenced
-by the different fields of \Rdmcontrol, \Rabstractcs, \Rabstractauto, and
-\Rcommand.
+by the different fields of \RdmDmcontrol, \RdmAbstractcs, \RdmAbstractauto, and
+\RdmCommand.
 
 \begin{figure}
    \centering
@@ -455,15 +456,15 @@ for each access size.
         \hline
         Access Size & Data Bits \\
         \hline
-        8 & \Rsbdatazero bits 7:0 \\
+        8 & \RdmSbdataZero bits 7:0 \\
         \hline
-        16 & \Rsbdatazero bits 15:0 \\
+        16 & \RdmSbdataZero bits 15:0 \\
         \hline
-        32 & \Rsbdatazero \\
+        32 & \RdmSbdataZero \\
         \hline
-        64 & \Rsbdataone, \Rsbdatazero \\
+        64 & \RdmSbdataOne, \RdmSbdataZero \\
         \hline
-        128 & \Rsbdatathree, \Rsbdatatwo, \Rsbdataone, \Rsbdatazero \\
+        128 & \RdmSbdataThree, \RdmSbdataTwo, \RdmSbdataOne, \RdmSbdataZero \\
         \hline
     \end{tabulary}
 \end{table}
@@ -514,45 +515,45 @@ Module that can be used to be permanently disable it. Since this is technology
 specific, it is not further addressed in this spec.
 
 Another option is to allow the DM to be unlocked only by users who have an
-access key. Between \Fauthenticated, \Fauthbusy, and \Rauthdata arbitrarily
-complex authentication mechanism can be supported.  When \Fauthenticated is
+access key. Between \FdmDmstatusAuthenticated, \FdmDmstatusAuthbusy, and \RdmAuthdata arbitrarily
+complex authentication mechanism can be supported.  When \FdmDmstatusAuthenticated is
 clear, the DM must not interact with the rest of the platform, nor expose
 details about the harts connected to the DM. All DM registers should read 0,
 while writes should be ignored, with the following mandatory exceptions:
 \begin{steps}{}
-    \item \Fauthenticated in \Rdmstatus is readable.
-    \item \Fauthbusy in \Rdmstatus is readable.
-    \item \Fversion in \Rdmstatus is readable.
-    \item \Fdmactive in \Rdmcontrol is readable and writable.
-    \item \Rauthdata is readable and writable.
+    \item \FdmDmstatusAuthenticated in \RdmDmstatus is readable.
+    \item \FdmDmstatusAuthbusy in \RdmDmstatus is readable.
+    \item \FdmDmstatusVersion in \RdmDmstatus is readable.
+    \item \FdmDmcontrolDmactive in \RdmDmcontrol is readable and writable.
+    \item \RdmAuthdata is readable and writable.
 \end{steps}
 
 \section{Version Detection}
 
 \begin{steps}{To detect the version of the Debug Module with a minimum of side
     effects, use the following procedure:}
-    \item Read \Rdmcontrol.
-    \item Write \Rdmcontrol, preserving \Fhartreset, \Fhasel, \Fhartsello, and
-        \Fhartselhi from the value that was read, setting \Fdmactive, and
+    \item Read \RdmDmcontrol.
+    \item Write \RdmDmcontrol, preserving \FdmDmcontrolHartreset, \FdmDmcontrolHasel, \FdmDmcontrolHartsello, and
+        \FdmDmcontrolHartselhi from the value that was read, setting \FdmDmcontrolDmactive, and
         clearing all the other bits.
-    \item Read \Rdmstatus, which contains \Fversion.
+    \item Read \RdmDmstatus, which contains \FdmDmstatusVersion.
 \end{steps}
 
 \begin{steps}{This has the following unavoidable side effects:}
-    \item \Fhaltreq is cleared, potentially preventing a halt request made by a
+    \item \FdmDmcontrolHaltreq is cleared, potentially preventing a halt request made by a
         previous debugger from taking effect.
-    \item \Fresumereq is cleared, potentially preventing a resume request made
+    \item \FdmDmcontrolResumereq is cleared, potentially preventing a resume request made
         by a previous debugger from taking effect.
-    \item \Fndmreset is deasserted, releasing the system from reset if a
+    \item \FdmDmcontrolNdmreset is deasserted, releasing the system from reset if a
         previous debugger had set it.
-    \item \Fdmactive is asserted, releasing the DM from reset. This in itself
+    \item \FdmDmcontrolDmactive is asserted, releasing the DM from reset. This in itself
         is not observable by any harts.
 \end{steps}
 
 This procedure is guaranteed to work in future versions of this spec.  The
-meaning of the \Rdmcontrol bits where \Fhartreset, \Fhasel, \Fhartsello, and
-\Fhartselhi currently reside might change, but preserving them will have no
-side effects. Clearing the bits of \Rdmcontrol not explicitly mentioned here
+meaning of the \RdmDmcontrol bits where \FdmDmcontrolHartreset, \FdmDmcontrolHasel, \FdmDmcontrolHartsello, and
+\FdmDmcontrolHartselhi currently reside might change, but preserving them will have no
+side effects. Clearing the bits of \RdmDmcontrol not explicitly mentioned here
 will have no side effects beyond the ones mentioned above.
 
 \section{Debug Module Registers} \label{dmdebbus}
@@ -565,7 +566,7 @@ When read, unimplemented Debug Module DMI Registers return 0. Writing them has
 no effect.
 
 For each register it is possible to determine that it is implemented by reading
-it and getting a non-zero value (e.g.\ \Rsbcs), or by checking bits in another
-register (e.g.\ \Fprogbufsize).
+it and getting a non-zero value (e.g.\ \RdmSbcs), or by checking bits in another
+register (e.g.\ \FdmAbstractcsProgbufsize).
 
 \input{dm_registers.tex}

--- a/debugger_implementation.tex
+++ b/debugger_implementation.tex
@@ -15,18 +15,18 @@ possibly while adding in some delay, or explicit checks for status bits.
 
 \section{Debug Module Interface Access} \label{dmiaccess}
 
-To read an arbitrary Debug Module register, select \Rdmi, and scan in a value
-with \Fop set to 1, and \Faddress set to the desired register address. In
+To read an arbitrary Debug Module register, select \RdtmDmi, and scan in a value
+with \FdtmDmiOp set to 1, and \FdmSbaddressZeroAddress set to the desired register address. In
 Update-DR the operation will start, and in Capture-DR its results will be
-captured into \Fdata.  If the operation didn't complete in time, \Fop will be 3
-and the value in \Fdata must be ignored. The busy condition must be cleared by
-writing \Fdmireset in \Rdtmcs, and then the second scan scan must be performed again.
-This process must be repeated until \Fop returns 0.
+captured into \FdmSbdataZeroData.  If the operation didn't complete in time, \FdtmDmiOp will be 3
+and the value in \FdmSbdataZeroData must be ignored. The busy condition must be cleared by
+writing \FdtmDtmcsDmireset in \RdtmDtmcs, and then the second scan scan must be performed again.
+This process must be repeated until \FdtmDmiOp returns 0.
 In later operations the debugger should allow for more time between Capture-DR and
 Update-DR.
 
-To write an arbitrary Debug Bus register, select \Rdmi, and scan in a value
-with \Fop set to 2, and \Faddress and \Fdata set to the desired register
+To write an arbitrary Debug Bus register, select \RdtmDmi, and scan in a value
+with \FdtmDmiOp set to 2, and \FdmSbaddressZeroAddress and \FdmSbdataZeroData set to the desired register
 address and data respectively. From then on everything happens exactly as with
 a read, except that a write is performed instead of the read.
 
@@ -38,32 +38,32 @@ inefficiency in typical JTAG use.
 A user will want to know as quickly as possible when a hart is halted (e.g.\ due
 to a breakpoint).  To efficiently determine which harts are halted when there
 are many harts, the debugger uses the {\tt haltsum} registers. Assuming the
-maximum number of harts exist, first it checks \Rhaltsumthree. For each bit set
-there, it writes \Fhartsel, and checks \Rhaltsumtwo. This process repeats
-through \Rhaltsumone and \Rhaltsumzero. Depending on how many harts exist, the
+maximum number of harts exist, first it checks \RdmHaltsumThree. For each bit set
+there, it writes \Fhartsel, and checks \RdmHaltsumTwo. This process repeats
+through \RdmHaltsumOne and \RdmHaltsumZero. Depending on how many harts exist, the
 process should start at one of the lower {\tt haltsum} registers.
 
 \section{Halting} \label{deb:halt}
 
-To halt one or more harts, the debugger selects them, sets \Fhaltreq, and then
-waits for \Fallhalted to indicate the harts are halted. Then it can clear
-\Fhaltreq to 0, or leave it high to catch a hart that resets while halted.
+To halt one or more harts, the debugger selects them, sets \FdmDmcontrolHaltreq, and then
+waits for \FdmDmstatusAllhalted to indicate the harts are halted. Then it can clear
+\FdmDmcontrolHaltreq to 0, or leave it high to catch a hart that resets while halted.
 
 \section{Running}
 
 First, the debugger should restore any registers that it has overwritten.
-Then it can let the selected harts run by setting \Fresumereq. Once
-\Fallresumeack is set, the debugger knows the hart has resumed, and it can
-clear \Fresumereq. Harts might halt very quickly after resuming (e.g.
+Then it can let the selected harts run by setting \FdmDmcontrolResumereq. Once
+\FdmDmstatusAllresumeack is set, the debugger knows the hart has resumed, and it can
+clear \FdmDmcontrolResumereq. Harts might halt very quickly after resuming (e.g.
 by hitting a software breakpoint) so the debugger cannot use
-\Fallhalted/\Fanyhalted to check whether the hart resumed.
+\FdmDmstatusAllhalted/\FdmDmstatusAnyhalted to check whether the hart resumed.
 
 \section{Single Step}
 
 Using the hardware single step feature is almost the same as regular running.
-The debugger just sets \Fstep in \Rdcsr before letting the hart run. The hart
+The debugger just sets \FcsrDcsrStep in \RcsrDcsr before letting the hart run. The hart
 behaves exactly as in the running case, except that interrupts may be disabled
-(depending on \Fstepie) and it only fetches and executes a single instruction
+(depending on \FcsrDcsrStepie) and it only fetches and executes a single instruction
 before re-entering Debug Mode.
 
 \section{Accessing Registers}
@@ -76,9 +76,9 @@ before re-entering Debug Mode.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rcommand & \Faarsize$=2$, \Ftransfer, \Fregno = 0x1008 & Read \Szero \\
+    Write & \RdmCommand & \FacAccessregisterAarsize$=2$, \FacAccessregisterTransfer, \FacAccessregisterRegno = 0x1008 & Read \Szero \\
     \hline
-    Read & \Rdatazero & - & Returns value that was in \Szero \\
+    Read & \RdmDataZero & - & Returns value that was in \Szero \\
     \hline
 \end{tabular}
 \medskip
@@ -89,9 +89,9 @@ before re-entering Debug Mode.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rdatazero & new value & \\
+    Write & \RdmDataZero & new value & \\
     \hline
-    Write & \Rcommand & \Faarsize$=2$, \Ftransfer, \Fwrite, \Fregno = 0x300 & Write \Rmstatus \\
+    Write & \RdmCommand & \FacAccessregisterAarsize$=2$, \FacAccessregisterTransfer, \FacAccessregisterWrite, \FacAccessregisterRegno = 0x300 & Write \Rmstatus \\
     \hline
 \end{tabular}
 \medskip
@@ -107,13 +107,13 @@ registers can be accessed by moving their value into/out of GPRs.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rprogbufzero & {\tt csrw s0, MSTATUS} & \\
+    Write & \RdmProgbufZero & {\tt csrw s0, MSTATUS} & \\
     \hline
     Write & {\tt progbuf1} & {\tt ebreak} & \\
     \hline
-    Write & \Rdatazero & new value & \\
+    Write & \RdmDataZero & new value & \\
     \hline
-    Write & \Rcommand & \Faarsize$=2$, \Fpostexec, \Ftransfer, \Fwrite, \Fregno = 0x1008 &
+    Write & \RdmCommand & \FacAccessregisterAarsize$=2$, \FacAccessregisterPostexec, \FacAccessregisterTransfer, \FacAccessregisterWrite, \FacAccessregisterRegno = 0x1008 &
         Write \Szero, then execute program buffer \\
     \hline
 \end{tabular}
@@ -125,15 +125,15 @@ registers can be accessed by moving their value into/out of GPRs.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rprogbufzero & {\tt fmv.x.s s0, f1} & \\
+    Write & \RdmProgbufZero & {\tt fmv.x.s s0, f1} & \\
     \hline
     Write & {\tt progbuf1} & {\tt ebreak} & \\
     \hline
-    Write & \Rcommand & \Fpostexec & Execute program buffer \\
+    Write & \RdmCommand & \FacAccessregisterPostexec & Execute program buffer \\
     \hline
-    Write & \Rcommand & \Ftransfer, \Fregno = 0x1008 & read \Szero \\
+    Write & \RdmCommand & \FacAccessregisterTransfer, \FacAccessregisterRegno = 0x1008 & read \Szero \\
     \hline
-    Read & \Rdatazero & - & Returns the value that was in \Fone \\
+    Read & \RdmDataZero & - & Returns the value that was in \Fone \\
     \hline
 \end{tabular}
 \medskip
@@ -150,11 +150,11 @@ With system bus access, addresses are physical system bus addresses.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rsbcs & \Fsbaccess$=2$, \Fsbreadonaddr & Setup \\
+    Write & \RdmSbcs & \FdmSbcsSbaccess$=2$, \FdmSbcsSbreadonaddr & Setup \\
     \hline
-    Write & \Rsbaddresszero & address & \\
+    Write & \RdmSbaddressZero & address & \\
     \hline
-    Read & \Rsbdatazero & - & Value read from memory \\
+    Read & \RdmSbdataZero & - & Value read from memory \\
     \hline
 \end{tabular}
 \medskip
@@ -165,20 +165,20 @@ With system bus access, addresses are physical system bus addresses.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rsbcs & \Fsbaccess$=2$, \Fsbreadonaddr, \Fsbreadondata, \Fsbautoincrement &
+    Write & \RdmSbcs & \FdmSbcsSbaccess$=2$, \FdmSbcsSbreadonaddr, \FdmSbcsSbreadondata, \FdmSbcsSbautoincrement &
             Turn on autoread and autoincrement \\
     \hline
-    Write & \Rsbaddresszero & address & Writing address triggers read and increment \\
+    Write & \RdmSbaddressZero & address & Writing address triggers read and increment \\
     \hline
-    Read & \Rsbdatazero & - & Value read from memory \\
+    Read & \RdmSbdataZero & - & Value read from memory \\
     \hline
-    Read & \Rsbdatazero & - & Next value read from memory \\
+    Read & \RdmSbdataZero & - & Next value read from memory \\
     \hline
     ... & ... & ... & ... \\
     \hline
-    Write & \Rsbcs & 0 & Disable autoread \\
+    Write & \RdmSbcs & 0 & Disable autoread \\
     \hline
-    Read & \Rsbdatazero & - & Get last value read from memory. \\
+    Read & \RdmSbdataZero & - & Get last value read from memory. \\
     \hline
 \end{tabular}
 \medskip
@@ -186,7 +186,7 @@ With system bus access, addresses are physical system bus addresses.
 \subsection{Using Program Buffer} \label{deb:mrprogbuf}
 
 Through the Program Buffer, the hart performs the memory accesses. Addresses
-are physical or virtual (depending on \Fmprven and other system
+are physical or virtual (depending on \FcsrDcsrMprven and other system
 configuration).
 
 \noindent Read a word from memory using program buffer:
@@ -195,17 +195,17 @@ configuration).
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rprogbufzero & {\tt lw s0, 0(s0)} & \\
+    Write & \RdmProgbufZero & {\tt lw s0, 0(s0)} & \\
     \hline
     Write & {\tt progbuf1} & {\tt ebreak} & \\
     \hline
-    Write & \Rdatazero & address & \\
+    Write & \RdmDataZero & address & \\
     \hline
-    Write & \Rcommand & \Fwrite, \Fpostexec, \Fregno = 0x1008 & Write \Szero, then execute program buffer \\
+    Write & \RdmCommand & \FacAccessregisterWrite, \FacAccessregisterPostexec, \FacAccessregisterRegno = 0x1008 & Write \Szero, then execute program buffer \\
     \hline
-    Write & \Rcommand & \Fregno = 0x1008 & Read \Szero \\
+    Write & \RdmCommand & \FacAccessregisterRegno = 0x1008 & Read \Szero \\
     \hline
-    Read & \Rdatazero & - & Value read from memory \\
+    Read & \RdmDataZero & - & Value read from memory \\
     \hline
 \end{tabular}
 \medskip
@@ -216,29 +216,29 @@ configuration).
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rprogbufzero & {\tt lw s1, 0(s0)} & \\
+    Write & \RdmProgbufZero & {\tt lw s1, 0(s0)} & \\
     \hline
     Write & {\tt progbuf1} & {\tt addi s0, s0, 4} & \\
     \hline
     Write & {\tt progbuf2} & {\tt ebreak} & \\
     \hline
-    Write & \Rdatazero & address & \\
+    Write & \RdmDataZero & address & \\
     \hline
-    Write & \Rcommand & \Fwrite, \Fpostexec, \Fregno = 0x1008 & Write \Szero, then execute program buffer \\
+    Write & \RdmCommand & \FacAccessregisterWrite, \FacAccessregisterPostexec, \FacAccessregisterRegno = 0x1008 & Write \Szero, then execute program buffer \\
     \hline
-    Write & \Rcommand & \Fpostexec, \Fregno = 0x1009 & Read \Sone, then execute program buffer \\
+    Write & \RdmCommand & \FacAccessregisterPostexec, \FacAccessregisterRegno = 0x1009 & Read \Sone, then execute program buffer \\
     \hline
-    Write & \Rabstractauto & \Fautoexecdata[0] & Set \Fautoexecdata[0] \\
+    Write & \RdmAbstractauto & \FdmAbstractautoAutoexecdata[0] & Set \FdmAbstractautoAutoexecdata[0] \\
     \hline
-    Read & \Rdatazero & - & Get value read from memory, then execute program buffer \\
+    Read & \RdmDataZero & - & Get value read from memory, then execute program buffer \\
     \hline
-    Read & \Rdatazero & - & Get next value read from memory, then execute program buffer \\
+    Read & \RdmDataZero & - & Get next value read from memory, then execute program buffer \\
     \hline
     ... & ... & ... & ... \\
     \hline
-    Write & \Rabstractauto & 0 & Clear \Fautoexecdata[0] \\
+    Write & \RdmAbstractauto & 0 & Clear \FdmAbstractautoAutoexecdata[0] \\
     \hline
-    Read & \Rdatazero & - & Get last value read from memory. \\
+    Read & \RdmDataZero & - & Get last value read from memory. \\
     \hline
 \end{tabular}
 \medskip
@@ -256,9 +256,9 @@ actual implementation may differ.
     \hline
     Write & \Rdataone & address & \\
     \hline
-    Write & \Rcommand & cmdtype=2, \Faamsize=2 & \\
+    Write & \RdmCommand & cmdtype=2, \FacAccessmemoryAamsize=2 & \\
     \hline
-    Read & \Rdatazero & - & Value read from memory \\
+    Read & \RdmDataZero & - & Value read from memory \\
     \hline
 \end{tabular}
 \medskip
@@ -269,19 +269,19 @@ actual implementation may differ.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rabstractauto & 1 & Re-execute the command when \Rdatazero is accessed \\
+    Write & \RdmAbstractauto & 1 & Re-execute the command when \RdmDataZero is accessed \\
     \hline
     Write & \Rdataone & address & \\
     \hline
-    Write & \Rcommand & cmdtype=2, \Faamsize=2, \Faampostincrement=1 & \\
+    Write & \RdmCommand & cmdtype=2, \FacAccessmemoryAamsize=2, \FacAccessmemoryAampostincrement=1 & \\
     \hline
-    Read & \Rdatazero & - & Read value, and trigger reading of next address \\
+    Read & \RdmDataZero & - & Read value, and trigger reading of next address \\
     \hline
     ... & ... & ... & ... \\
     \hline
-    Write & \Rabstractauto & 0 & Disable auto-exec \\
+    Write & \RdmAbstractauto & 0 & Disable auto-exec \\
     \hline
-    Read & \Rdatazero & - & Get last value read from memory. \\
+    Read & \RdmDataZero & - & Get last value read from memory. \\
     \hline
 \end{tabular}
 \medskip
@@ -298,9 +298,9 @@ With system bus access, addresses are physical system bus addresses.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rsbaddresszero & address & \\
+    Write & \RdmSbaddressZero & address & \\
     \hline
-    Write & \Rsbdatazero & value & \\
+    Write & \RdmSbdataZero & value & \\
     \hline
 \end{tabular}
 \medskip
@@ -311,17 +311,17 @@ With system bus access, addresses are physical system bus addresses.
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rsbcs & \Fsbaccess$=2$, \Fsbautoincrement & Turn on autoincrement \\
+    Write & \RdmSbcs & \FdmSbcsSbaccess$=2$, \FdmSbcsSbautoincrement & Turn on autoincrement \\
     \hline
-    Write & \Rsbaddresszero & address & \\
+    Write & \RdmSbaddressZero & address & \\
     \hline
-    Write & \Rsbdatazero & value0 & \\
+    Write & \RdmSbdataZero & value0 & \\
     \hline
-    Write & \Rsbdatazero & value1 & \\
+    Write & \RdmSbdataZero & value1 & \\
     \hline
     ... & ... & ... & ... \\
     \hline
-    Write & \Rsbdatazero & valueN & \\
+    Write & \RdmSbdataZero & valueN & \\
     \hline
 \end{tabular}
 \medskip
@@ -329,7 +329,7 @@ With system bus access, addresses are physical system bus addresses.
 \subsection{Using Program Buffer} \label{deb:mrprogbuf}
 
 Through the Program Buffer, the hart performs the memory accesses. Addresses
-are physical or virtual (depending on \Fmprven and other system
+are physical or virtual (depending on \FcsrDcsrMprven and other system
 configuration).
 
 \noindent Write a word to memory using program buffer:
@@ -338,17 +338,17 @@ configuration).
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rprogbufzero & {\tt sw s1, 0(s0)} & \\
+    Write & \RdmProgbufZero & {\tt sw s1, 0(s0)} & \\
     \hline
     Write & {\tt progbuf1} & {\tt ebreak} & \\
     \hline
-    Write & \Rdatazero & address & \\
+    Write & \RdmDataZero & address & \\
     \hline
-    Write & \Rcommand & \Fwrite, \Fregno = 0x1008 & Write \Szero \\
+    Write & \RdmCommand & \FacAccessregisterWrite, \FacAccessregisterRegno = 0x1008 & Write \Szero \\
     \hline
-    Write & \Rdatazero & value & \\
+    Write & \RdmDataZero & value & \\
     \hline
-    Write & \Rcommand & \Fwrite, \Fpostexec, \Fregno = 0x1009 & Write \Sone, then execute program buffer \\
+    Write & \RdmCommand & \FacAccessregisterWrite, \FacAccessregisterPostexec, \FacAccessregisterRegno = 0x1009 & Write \Sone, then execute program buffer \\
     \hline
 \end{tabular}
 \medskip
@@ -359,29 +359,29 @@ configuration).
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rprogbufzero & {\tt sw s1, 0(s0)} & \\
+    Write & \RdmProgbufZero & {\tt sw s1, 0(s0)} & \\
     \hline
     Write & {\tt progbuf1} & {\tt addi s0, s0, 4} & \\
     \hline
     Write & {\tt progbuf2} & {\tt ebreak} & \\
     \hline
-    Write & \Rdatazero & address & \\
+    Write & \RdmDataZero & address & \\
     \hline
-    Write & \Rcommand & \Fwrite, \Fregno = 0x1008 & Write \Szero \\
+    Write & \RdmCommand & \FacAccessregisterWrite, \FacAccessregisterRegno = 0x1008 & Write \Szero \\
     \hline
-    Write & \Rdatazero & value0 & \\
+    Write & \RdmDataZero & value0 & \\
     \hline
-    Write & \Rcommand & \Fwrite, \Fpostexec, \Fregno = 0x1009 & Write \Sone, then execute program buffer \\
+    Write & \RdmCommand & \FacAccessregisterWrite, \FacAccessregisterPostexec, \FacAccessregisterRegno = 0x1009 & Write \Sone, then execute program buffer \\
     \hline
-    Write & \Rabstractauto & \Fautoexecdata[0] & Set \Fautoexecdata[0] \\
+    Write & \RdmAbstractauto & \FdmAbstractautoAutoexecdata[0] & Set \FdmAbstractautoAutoexecdata[0] \\
     \hline
-    Write & \Rdatazero & value1 & \\
+    Write & \RdmDataZero & value1 & \\
     \hline
     ... & ... & ... & ... \\
     \hline
-    Write & \Rdatazero & valueN & \\
+    Write & \RdmDataZero & valueN & \\
     \hline
-    Write & \Rabstractauto & 0 & Clear \Fautoexecdata[0] \\
+    Write & \RdmAbstractauto & 0 & Clear \FdmAbstractautoAutoexecdata[0] \\
     \hline
 \end{tabular}
 \medskip
@@ -399,9 +399,9 @@ actual implementation may differ.
     \hline
     Write & \Rdataone & address & \\
     \hline
-    Write & \Rdatazero & value & \\
+    Write & \RdmDataZero & value & \\
     \hline
-    Write & \Rcommand & cmdtype=2, \Faamsize=2, write=1 & \\
+    Write & \RdmCommand & cmdtype=2, \FacAccessmemoryAamsize=2, write=1 & \\
     \hline
 \end{tabular}
 \medskip
@@ -414,21 +414,21 @@ actual implementation may differ.
     \hline
     Write & \Rdataone & address & \\
     \hline
-    Write & \Rdatazero & value0 & \\
+    Write & \RdmDataZero & value0 & \\
     \hline
-    Write & \Rcommand & cmdtype=2, \Faamsize=2, write=1, \Faampostincrement=1 & \\
+    Write & \RdmCommand & cmdtype=2, \FacAccessmemoryAamsize=2, write=1, \FacAccessmemoryAampostincrement=1 & \\
     \hline
-    Write & \Rabstractauto & 1 & Re-execute the command when \Rdatazero is accessed \\
+    Write & \RdmAbstractauto & 1 & Re-execute the command when \RdmDataZero is accessed \\
     \hline
-    Write & \Rdatazero & value1 & \\
+    Write & \RdmDataZero & value1 & \\
     \hline
-    Write & \Rdatazero & value2 & \\
+    Write & \RdmDataZero & value2 & \\
     \hline
     ... & ... & ... & ... \\
     \hline
-    Write & \Rdatazero & valueN & \\
+    Write & \RdmDataZero & valueN & \\
     \hline
-    Write & \Rabstractauto & 0 & Disable auto-exec \\
+    Write & \RdmAbstractauto & 0 & Disable auto-exec \\
     \hline
 \end{tabular}
 \medskip
@@ -447,9 +447,9 @@ executed, to be used as an instruction breakpoint in ROM:
 
 \begin{tabulary}{\textwidth}{|r|r|L|}
     \hline
-    \Rtdataone & 0x105c & action=1, match=0, m=1, s=1, u=1, execute=1 \\
+    \RcsrTdataOne & 0x105c & action=1, match=0, m=1, s=1, u=1, execute=1 \\
     \hline
-    \Rtdatatwo & 0x80001234 & address \\
+    \RcsrTdataTwo & 0x80001234 & address \\
     \hline
 \end{tabulary}
 \medskip
@@ -458,9 +458,9 @@ executed, to be used as an instruction breakpoint in ROM:
 
 \begin{tabulary}{\textwidth}{|r|r|L|}
     \hline
-    \Rtdataone & 0x4159 & timing=1, action=1, match=0, m=1, s=1, u=1, load=1 \\
+    \RcsrTdataOne & 0x4159 & timing=1, action=1, match=0, m=1, s=1, u=1, load=1 \\
     \hline
-    \Rtdatatwo & 0x80007f80 & address \\
+    \RcsrTdataTwo & 0x80007f80 & address \\
     \hline
 \end{tabulary}
 \medskip
@@ -470,13 +470,13 @@ executed, to be used as an instruction breakpoint in ROM:
 
 \begin{tabulary}{\textwidth}{|r|r|L|}
     \hline
-    \Rtdataone 0 & 0x195a & action=1, chain=1, match=2, m=1, s=1, u=1, store=1 \\
+    \RcsrTdataOne 0 & 0x195a & action=1, chain=1, match=2, m=1, s=1, u=1, store=1 \\
     \hline
-    \Rtdatatwo 0 & 0x80007c80 & start address (inclusive) \\
+    \RcsrTdataTwo 0 & 0x80007c80 & start address (inclusive) \\
     \hline
-    \Rtdataone 1 & 0x11da & action=1, match=3, m=1, s=1, u=1, store=1 \\
+    \RcsrTdataOne 1 & 0x11da & action=1, match=3, m=1, s=1, u=1, store=1 \\
     \hline
-    \Rtdatatwo 1 & 0x80007cf0 & end address (exclusive) \\
+    \RcsrTdataTwo 1 & 0x80007cf0 & end address (exclusive) \\
     \hline
 \end{tabulary}
 \medskip
@@ -486,9 +486,9 @@ executed, to be used as an instruction breakpoint in ROM:
 
 \begin{tabulary}{\textwidth}{|r|r|L|}
     \hline
-    \Rtdataone & 0x10da & action=1, match=1, m=1, s=1, u=1, store=1 \\
+    \RcsrTdataOne & 0x10da & action=1, match=1, m=1, s=1, u=1, store=1 \\
     \hline
-    \Rtdatatwo & 0x81237fff & 16 bits to match exactly, then 0, then all ones. \\
+    \RcsrTdataTwo & 0x81237fff & 16 bits to match exactly, then 0, then all ones. \\
     \hline
 \end{tabulary}
 \medskip
@@ -498,13 +498,13 @@ executed, to be used as an instruction breakpoint in ROM:
 
 \begin{tabulary}{\textwidth}{|r|r|L|}
     \hline
-    \Rtdataone 0 & 0x41a59 & timing=1, action=1, chain=1, match=4, m=1, s=1, u=1, load=1 \\
+    \RcsrTdataOne 0 & 0x41a59 & timing=1, action=1, chain=1, match=4, m=1, s=1, u=1, load=1 \\
     \hline
-    \Rtdatatwo 0 & 0xfff03090 & Mask for low half, then match for low half \\
+    \RcsrTdataTwo 0 & 0xfff03090 & Mask for low half, then match for low half \\
     \hline
-    \Rtdataone 1 & 0x412d9 & timing=1, action=1, match=5, m=1, s=1, u=1, load=1 \\
+    \RcsrTdataOne 1 & 0x412d9 & timing=1, action=1, match=5, m=1, s=1, u=1, load=1 \\
     \hline
-    \Rtdatatwo 1 & 0xefff8675 & Mask for high half, then match for high half \\
+    \RcsrTdataTwo 1 & 0xefff8675 & Mask for high half, then match for high half \\
     \hline
 \end{tabulary}
 \medskip
@@ -517,7 +517,7 @@ access memory or a CSR that is not implemented. A typical debugger will not
 know enough about the platform to know what's going to happen, and must attempt
 the access to determine the outcome.
 
-When an exception occurs while executing the Program Buffer, \Fcmderr becomes
+When an exception occurs while executing the Program Buffer, \FdmAbstractcsCmderr becomes
 set. The debugger can check this field to see whether a program encountered an
 exception.  If there was an exception, it's left to the debugger to know what
 must have caused it.
@@ -526,7 +526,7 @@ must have caused it.
 
 There are a variety of instructions to transfer data between GPRs and the {\tt
 data} registers. They are either loads/stores or CSR reads/writes. The specific
-addresses also vary. This is all specified in \Rhartinfo. The examples here use
+addresses also vary. This is all specified in \RdmHartinfo. The examples here use
 the pseudo-op {\tt transfer dest, src} to represent all these options.
 
 Halt the hart for a minimum amount of time to perform a single memory write:
@@ -535,7 +535,7 @@ Halt the hart for a minimum amount of time to perform a single memory write:
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rprogbufzero & {\tt transfer arg2, s0} & Save \Szero \\
+    Write & \RdmProgbufZero & {\tt transfer arg2, s0} & Save \Szero \\
     \hline
     Write & {\tt progbuf1} & {\tt transfer s0, arg0} & Read first argument (address) \\
     \hline
@@ -551,15 +551,15 @@ Halt the hart for a minimum amount of time to perform a single memory write:
     \hline
     Write & {\tt progbuf7} & {\tt ebreak} & \\
     \hline
-    Write & \Rdatazero & address & \\
+    Write & \RdmDataZero & address & \\
     \hline
     Write & {\tt data1} & data & \\
     \hline
-    Write & \Rcommand & 0x10000000 & Perform quick access \\
+    Write & \RdmCommand & 0x10000000 & Perform quick access \\
     \hline
 \end{tabular}
 
-This shows an example of setting the \Fm bit in \Rmcontrol to
+This shows an example of setting the \FcsrMcontrolM bit in \RcsrMcontrol to
 enable a hardware breakpoint in M-mode.
 Similar quick access instructions could have been used previously
 to configure the trigger that is being enabled here:
@@ -568,17 +568,17 @@ to configure the trigger that is being enabled here:
     \hline
     Op & Address & Value & Comment \\
     \hline
-    Write & \Rprogbufzero & {\tt transfer arg0, s0} & Save \Szero \\
+    Write & \RdmProgbufZero & {\tt transfer arg0, s0} & Save \Szero \\
     \hline
-    Write & {\tt progbuf1} & {\tt li s0, (1 << 6)} & Form the mask for \Fm bit \\
+    Write & {\tt progbuf1} & {\tt li s0, (1 << 6)} & Form the mask for \FcsrMcontrolM bit \\
     \hline
-    Write & {\tt progbuf2} & {\tt csrrs x0, \Rtdataone, s0} & Apply the mask to \Rmcontrol \\
+    Write & {\tt progbuf2} & {\tt csrrs x0, \RcsrTdataOne, s0} & Apply the mask to \RcsrMcontrol \\
     \hline
     Write & {\tt progbuf3} & {\tt transfer s0, arg2} & Restore \Szero \\
     \hline
     Write & {\tt progbuf4} & {\tt ebreak} & \\
    \hline
-    Write & \Rcommand & 0x10000000 & Perform quick access \\
+    Write & \RdmCommand & 0x10000000 & Perform quick access \\
    \hline
 \end{tabular}
 

--- a/implementations.tex
+++ b/implementations.tex
@@ -30,8 +30,8 @@ When the halt request bit is set, the Debug Module raises a special interrupt
 to the selected harts. This interrupt causes each
 hart to enter Debug Mode and jump to a defined
 memory region that is serviced by the DM.
-When taking this exception, \Rpc is saved to \Rdpc and \Fcause is updated
-in \Rdcsr.
+When taking this exception, \Rpc is saved to \RcsrDpc and \FcsrDcsrCause is updated
+in \RcsrDcsr.
 
 The code in the Debug Module causes the hart to execute a ``park loop.''
 In the park loop the hart writes its \Rmhartid to a
@@ -42,11 +42,11 @@ to determine whether the debugger wants it to
 execute the Program Buffer or perform a resume.
 
 To execute an abstract command, the DM first populates some internal words of
-program buffer according to \Rcommand. When \Ftransfer is set, the DM
+program buffer according to \RdmCommand. When \FacAccessregisterTransfer is set, the DM
 populates these words with {\tt lw <gpr>, 0x400(zero)} or {\tt sw 0x400(zero), <gpr>}.
 64- and 128-bit accesses use {\tt ld}/{\tt sd} and {\tt lq}/{\tt sq}
-respectively. If \Ftransfer is not set, the DM populates these instructions as {\tt nop}s.
-If \Fexecute is set, execution continues to the debugger-controlled Program Buffer,
+respectively. If \FacAccessregisterTransfer is not set, the DM populates these instructions as {\tt nop}s.
+If \FcsrMcontrolExecute is set, execution continues to the debugger-controlled Program Buffer,
 otherwise the DM causes a {\tt ebreak} to execute immediately.
 
 When {\tt ebreak} is executed (indicating the end of the
@@ -57,17 +57,17 @@ write to an address in the Debug Module which indicates exception.
 This address is considered I/O for {\tt fence} instructions (see \#\ref{fence}
 on page \pageref{fence}).
 Then the hart jumps back to the park loop.
-The DM infers from the write that there was an exception, and sets \Fcmderr appropriately.
+The DM infers from the write that there was an exception, and sets \FdmAbstractcsCmderr appropriately.
 
 To resume execution, the debug module sets a flag which causes the hart to execute a {\tt dret}.
-When {\tt dret} is executed, \Rpc is restored from \Rdpc and normal execution resumes at the
-privilege set by \Fprv.
+When {\tt dret} is executed, \Rpc is restored from \RcsrDpc and normal execution resumes at the
+privilege set by \FcsrDcsrPrv.
 
-\Rdatazero etc. are mapped into regular memory at an address relative to \Rzero
+\RdmDataZero etc. are mapped into regular memory at an address relative to \Rzero
 with only a 12-bit {\tt imm}. The exact address is an implementation
 detail that a debugger must not rely on. For example, the {\tt data}
 registers might be mapped to {\tt 0x400}.
 
-For additional flexibility, \Rprogbufzero, etc. are mapped into regular memory
-immediately preceding \Rdatazero, in order to form a contiguous region of memory which
+For additional flexibility, \RdmProgbufZero, etc. are mapped into regular memory
+immediately preceding \RdmDataZero, in order to form a contiguous region of memory which
 can be used for either program execution or data transfer.

--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -17,8 +17,8 @@
 \usepackage{xspace}
 \newcommand{\defregname}[2]{\providecommand{#1}{{\tt #2}\xspace}}
 \newcommand{\deffieldname}[2]{\providecommand{#1}{{$|#2|$}\xspace}}
-\deffieldname{\Fmprv}{MPRV}
-\deffieldname{\Fmie}{MIE}
+\deffieldname{\FcsrMcontrolMprv}{MPRV}
+\deffieldname{\FcsrMcontrolMie}{MIE}
 \deffieldname{\Fmxl}{MXL}
 \defregname{\Rmisa}{misa}
 \defregname{\Rmstatus}{mstatus}
@@ -90,6 +90,7 @@ Alex Bradbury,
 Chuanhua Chang,
 Zhong-Ho Chen,
 Monte Dalrymple,
+Paul Donahue,
 Vyacheslav Dyachenko,
 Peter Egold,
 Markus Goehrle,

--- a/trigger.tex
+++ b/trigger.tex
@@ -18,25 +18,25 @@ Triggers do not fire while in Debug Mode.
 
 \begin{steps}{Each trigger may support a variety of features. A debugger can
     build a list of all triggers and their features as follows:}
-\item Write 0 to \Rtselect. If this results in an illegal instruction
+\item Write 0 to \RcsrTselect. If this results in an illegal instruction
     exception, then there are no triggers implemented.
-\item Read back \Rtselect and check that it contains the written value. If not,
+\item Read back \RcsrTselect and check that it contains the written value. If not,
     exit the loop.
-\item Read \Rtinfo.
-\item If that caused an exception, the debugger must read \Rtdataone to
-    discover the type. (If \Ftype is 0, this trigger doesn't exist. Exit the
+\item Read \RcsrTinfo.
+\item If that caused an exception, the debugger must read \RcsrTdataOne to
+    discover the type. (If \FcsrTdataOneType is 0, this trigger doesn't exist. Exit the
     loop.)
-\item If \Finfo is 1, this trigger doesn't exist. Exit the loop.
-\item Otherwise, the selected trigger supports the types discovered in \Finfo.
-\item Repeat, incrementing the value in \Rtselect.
+\item If \FcsrTinfoInfo is 1, this trigger doesn't exist. Exit the loop.
+\item Otherwise, the selected trigger supports the types discovered in \FcsrTinfoInfo.
+\item Repeat, incrementing the value in \RcsrTselect.
 \end{steps}
 
 \begin{commentary}
-    The above algorithm reads back \Rtselect so that implementations which have
-    $2^n$ triggers only need to implement $n$ bits of \Rtselect.
+    The above algorithm reads back \RcsrTselect so that implementations which have
+    $2^n$ triggers only need to implement $n$ bits of \RcsrTselect.
 
-    The algorithm checks \Rtinfo and \Ftype in case the implementation has $m$
-    bits of \Rtselect but fewer than $2^m$ triggers.
+    The algorithm checks \RcsrTinfo and \FcsrTdataOneType in case the implementation has $m$
+    bits of \RcsrTselect but fewer than $2^m$ triggers.
 \end{commentary}
 
 It is possible for a trigger with the ``enter Debug Mode'' action (1) and another
@@ -46,7 +46,7 @@ implementation-dependent which of the two happens first.  This ensures both
 that the presence of an external debugger doesn't affect execution and that a
 trigger set by user code doesn't affect the external debugger. If this is not
 implemented, then the hart must enter Debug Mode and ignore the breakpoint
-exception. In the latter case, \Fhit of the trigger whose action is 0 must still
+exception. In the latter case, \FcsrMcontrolHit of the trigger whose action is 0 must still
 be set, giving a debugger an opportunity to handle this case. What happens with
 trace actions when triggers with different actions are also firing is left to
 the trace specification.
@@ -55,7 +55,7 @@ the trace specification.
 \label{sec:mmtrigger}
 
 Triggers can be used for native debugging. On a fully featured system triggers
-will be set using \Fu or \Fs, and when firing they can cause a breakpoint exception
+will be set using \FcsrMcontrolU or \FcsrMcontrolS, and when firing they can cause a breakpoint exception
 to trap to a more privileged mode. It is possible to set triggers natively to
 fire in M mode as well. In that case there is no higher privilege mode to trap
 to. When such a trigger causes a breakpoint exception while already in a trap
@@ -67,11 +67,11 @@ implement one of two solutions to this problem. This way triggers can be useful
 for native debugging of even M mode code.
 
 The simple solution is to have the hardware prevent triggers with action=0 from
-firing while in M mode and while \Fmie in \Rmstatus is 0. Its limitation is
+firing while in M mode and while \FcsrMcontrolMie in \Rmstatus is 0. Its limitation is
 that interrupts might be disabled at other times when a user might want
 triggers to fire.
 
-A more complex solution is to implement \Fmte and \Fmpte in \Rtcontrol. This
+A more complex solution is to implement \FcsrTcontrolMte and \FcsrTcontrolMpte in \RcsrTcontrol. This
 solution has the benefit that it only disables triggers during the trap
 handler.
 

--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -4,23 +4,23 @@
         \begin{steps}{This command gives the debugger access to CPU registers
         and allows it to execute the Program Buffer.
         It performs the following sequence of operations:}
-        \item If \Fwrite is clear and \Ftransfer is set, then copy data from
-            the register specified by \Fregno into the {\tt arg0} region of
+        \item If \FacAccessregisterWrite is clear and \FacAccessregisterTransfer is set, then copy data from
+            the register specified by \FacAccessregisterRegno into the {\tt arg0} region of
             {\tt data}, and perform any side effects that occur when this
             register is read from M-mode.
-        \item If \Fwrite is set and \Ftransfer is set, then copy data from the
+        \item If \FacAccessregisterWrite is set and \FacAccessregisterTransfer is set, then copy data from the
             {\tt arg0} region of {\tt data} into the register specified by
-            \Fregno, and perform any side effects that occur when this register
+            \FacAccessregisterRegno, and perform any side effects that occur when this register
             is written from M-mode.
-        \item If \Faarpostincrement is set, increment \Fregno.
-        \item Execute the Program Buffer, if \Fpostexec is set.
+        \item If \FacAccessregisterAarpostincrement is set, increment \FacAccessregisterRegno.
+        \item Execute the Program Buffer, if \FacAccessregisterPostexec is set.
         \end{steps}
 
-        If any of these operations fail, \Fcmderr is set and none of the
+        If any of these operations fail, \FdmAbstractcsCmderr is set and none of the
         remaining steps are executed. An implementation may detect an upcoming
         failure early, and fail the overall command before it reaches the step
         that would cause failure. If the failure is that the requested register
-        does not exist in the hart, \Fcmderr must be set to 3 (exception).
+        does not exist in the hart, \FdmAbstractcsCmderr must be set to 3 (exception).
 
         Debug Modules must implement this command
         and must support read and write access to all GPRs when the selected hart is halted.
@@ -35,7 +35,7 @@
             \label{tab:regno}
             \begin{tabulary}{\textwidth}{|r|l|}
                 \hline
-                0x0000 -- 0x0fff &amp; CSRs. The ``PC'' can be accessed here through \Rdpc.
+                0x0000 -- 0x0fff &amp; CSRs. The ``PC'' can be accessed here through \RcsrDpc.
                 \\
                 \hline
                 0x1000 -- 0x101f &amp; GPRs \\
@@ -49,7 +49,7 @@
         \end{table}
 
         \begin{commentary}
-            The encoding of \Faarsize was chosen to match \Fsbaccess in \Rsbcs.
+            The encoding of \FacAccessregisterAarsize was chosen to match \FdmSbcsSbaccess in \RdmSbcs.
         \end{commentary}
 
         This command modifies {\tt arg0} only when a register is read. The
@@ -66,8 +66,8 @@
 
             4: Access the lowest 128 bits of the register.
 
-            If \Faarsize specifies a size larger than the register's actual size,
-            then the access must fail. If a register is accessible, then reads of \Faarsize
+            If \FacAccessregisterAarsize specifies a size larger than the register's actual size,
+            then the access must fail. If a register is accessible, then reads of \FacAccessregisterAarsize
             less than or equal to the register's actual size must be supported.
 
             This field controls the Argument Width as referenced in
@@ -76,27 +76,27 @@
         <field name="aarpostincrement" bits="19">
             0: No effect. This variant must be supported.
 
-            1: After a successful register access, \Fregno is incremented
+            1: After a successful register access, \FacAccessregisterRegno is incremented
             (wrapping around to 0). Supporting this variant is optional.
         </field>
         <field name="postexec" bits="18">
             0: No effect. This variant must be supported, and is the only
-            supported one if \Fprogbufsize is 0.
+            supported one if \FdmAbstractcsProgbufsize is 0.
 
             1: Execute the program in the Program Buffer exactly once after
             performing the transfer, if any. Supporting this variant is
             optional.
         </field>
         <field name="transfer" bits = "17">
-            0: Don't do the operation specified by \Fwrite.
+            0: Don't do the operation specified by \FacAccessregisterWrite.
 
-            1: Do the operation specified by \Fwrite.
+            1: Do the operation specified by \FacAccessregisterWrite.
 
             This bit can be used to just execute the Program Buffer without
-            having to worry about placing valid values into \Faarsize or \Fregno.
+            having to worry about placing valid values into \FacAccessregisterAarsize or \FacAccessregisterRegno.
         </field>
         <field name="write" bits="16">
-            When \Ftransfer is set:
+            When \FacAccessregisterTransfer is set:
             0: Copy data from the specified register into {\tt arg0} portion
                of {\tt data}.
 
@@ -106,17 +106,17 @@
         <field name="regno" bits="15:0">
           Number of the register to access, as described in
           Table~\ref{tab:regno}.
-          \Rdpc may be used as an alias for PC if this command is
+          \RcsrDpc may be used as an alias for PC if this command is
           supported on a non-halted hart.
         </field>
     </register>
 
     <register name="Quick Access">
         \begin{steps}{Perform the following sequence of operations:}
-        \item If the hart is halted, the command  sets \Fcmderr to ``halt/resume'' and does not continue.
+        \item If the hart is halted, the command  sets \FdmAbstractcsCmderr to ``halt/resume'' and does not continue.
         \item Halt the hart. If the hart halts for some other reason (e.g. breakpoint), the command
-            sets \Fcmderr to ``halt/resume'' and does not continue.
-        \item Execute the Program Buffer. If an exception occurs, \Fcmderr is set to ``exception''
+            sets \FdmAbstractcsCmderr to ``halt/resume'' and does not continue.
+        \item Execute the Program Buffer. If an exception occurs, \FdmAbstractcsCmderr is set to ``exception''
             and the program buffer execution ends, but the quick access command continues.
         \item Resume the hart.
         \end{steps}
@@ -138,13 +138,13 @@
             registers, etc. The command performs the following sequence of
             operations:}
         \item Copy data from the memory location specified in {\tt arg1} into the
-            {\tt arg0} portion of {\tt data}, if \Fwrite is clear.
+            {\tt arg0} portion of {\tt data}, if \FacAccessregisterWrite is clear.
         \item Copy data from the {\tt arg0} portion of {\tt data} into the
-            memory location specified in {\tt arg1}, if \Fwrite is set.
-        \item If \Faampostincrement is set, increment {\tt arg1}.
+            memory location specified in {\tt arg1}, if \FacAccessregisterWrite is set.
+        \item If \FacAccessmemoryAampostincrement is set, increment {\tt arg1}.
         \end{steps}
 
-        If any of these operations fail, \Fcmderr is set and none of the
+        If any of these operations fail, \FdmAbstractcsCmderr is set and none of the
         remaining steps are executed. An access may only fail if the hart,
         running M-mode code, might encounter that same failure when it attempts
         the same access.
@@ -159,11 +159,11 @@
         support memory accesses while the hart is halted.
 
         \begin{commentary}
-            The encoding of \Faamsize was chosen to match \Fsbaccess in \Rsbcs.
+            The encoding of \FacAccessmemoryAamsize was chosen to match \FdmSbcsSbaccess in \RdmSbcs.
         \end{commentary}
 
         This command modifies {\tt arg0} only when memory is read. It modifies
-        {\tt arg1} only if \Faampostincrement is set.  The other {\tt data}
+        {\tt arg1} only if \FacAccessmemoryAampostincrement is set.  The other {\tt data}
         registers are not changed.
 
         <field name="cmdtype" bits="31:24">
@@ -177,7 +177,7 @@
             0: Addresses are physical (to the hart they are performed on).
 
             1: Addresses are virtual, and translated the way they would be from
-            M-mode, with \Fmprv set.
+            M-mode, with \FcsrMcontrolMprv set.
         </field>
         <field name="aamsize" bits="22:20">
             0: Access the lowest 8 bits of the memory location.
@@ -193,7 +193,7 @@
         <field name="aampostincrement" bits="19">
             After a memory access has completed, if this bit is 1, increment
             {\tt arg1} (which contains the address used) by the number of bytes
-            encoded in \Faamsize.
+            encoded in \FacAccessmemoryAamsize.
         </field>
         <field name="0" bits="18:17" />
         <field name="write" bits="16">

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -3,7 +3,7 @@
 
     <register name="Debug Control and Status" short="dcsr" address="0x7b0">
         \begin{commentary}
-            \Fcause priorities are assigned such that the least predictable
+            \FcsrDcsrCause priorities are assigned such that the least predictable
             events have the highest priority.
         \end{commentary}
 
@@ -68,17 +68,17 @@
             Explains why Debug Mode was entered.
 
             When there are multiple reasons to enter Debug Mode in a single
-            cycle, hardware should set \Fcause to the cause with the highest
+            cycle, hardware should set \FcsrDcsrCause to the cause with the highest
             priority.
 
             1: An {\tt ebreak} instruction was executed. (priority 3)
 
             2: The Trigger Module caused a breakpoint exception. (priority 4)
 
-            3: The debugger requested entry to Debug Mode using \Fhaltreq.
+            3: The debugger requested entry to Debug Mode using \FdmDmcontrolHaltreq.
             (priority 1)
 
-            4: The hart single stepped because \Fstep was set. (priority 0, lowest)
+            4: The hart single stepped because \FcsrDcsrStep was set. (priority 0, lowest)
 
             5: The hart halted directly out of reset due to \Fresethaltreq. It
             is also acceptable to report 3 when this happens. (priority 2)
@@ -90,9 +90,9 @@
         </field>
         <field name="0" bits="5" access="R" reset="0" />
         <field name="mprven" bits="4" access="WARL" reset="Preset">
-            0: \Fmprv in \Rmstatus is ignored in Debug Mode.
+            0: \FcsrMcontrolMprv in \Rmstatus is ignored in Debug Mode.
 
-            1: \Fmprv in \Rmstatus takes effect in Debug Mode.
+            1: \FcsrMcontrolMprv in \Rmstatus takes effect in Debug Mode.
 
             Implementing this bit is optional. It may be tied to either 0 or 1.
 	</field>
@@ -126,7 +126,7 @@
     </register>
 
     <register name="Debug PC" short="dpc" address="0x7b1">
-        Upon entry to debug mode, \Rdpc is updated with the virtual address of
+        Upon entry to debug mode, \RcsrDpc is updated with the virtual address of
         the next instruction to be executed. The behavior is described in more
         detail in Table~\ref{tab:dpc}.
 
@@ -145,8 +145,8 @@
         that don't change program flow, the destination PC on taken
         jumps/branches, etc. \\
         \hline
-        trigger module &amp; If \Ftiming is 0, the address of the
-        instruction which caused the trigger to fire. If \Ftiming is 1, the
+        trigger module &amp; If \FcsrMcontrolTiming is 0, the address of the
+        instruction which caused the trigger to fire. If \FcsrMcontrolTiming is 1, the
         address of the next instruction to be executed at the time that
         debug mode was entered. \\
         \hline
@@ -157,19 +157,19 @@
         \end{table}
 
         When resuming, the hart's PC is updated to the virtual address stored in
-        \Rdpc. A debugger may write \Rdpc to change where the hart resumes.
+        \RcsrDpc. A debugger may write \RcsrDpc to change where the hart resumes.
         <field name="dpc" bits="DXLEN-1:0" access="R/W" reset="0" />
     </register>
 
     <register name="Debug Scratch Register 0" short="dscratch0" address="0x7b2">
         Optional scratch register that can be used by implementations that need
-        it. A debugger must not write to this register unless \Rhartinfo
+        it. A debugger must not write to this register unless \RdmHartinfo
         explicitly mentions it (the Debug Module may use this register internally).
     </register>
 
     <register name="Debug Scratch Register 1" short="dscratch1" address="0x7b3">
         Optional scratch register that can be used by implementations that need
-        it. A debugger must not write to this register unless \Rhartinfo
+        it. A debugger must not write to this register unless \RdmHartinfo
         explicitly mentions it (the Debug Module may use this register internally).
     </register>
 </registers>

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -1,11 +1,11 @@
-<registers name="Debug Module Debug Bus Registers" prefix="DMI_">
+<registers name="Debug Module Debug Bus Registers" prefix="DM_">
 
     <!-- =============== halt/reset/select hart  =============== -->
 
     <register name="Debug Module Status" short="dmstatus" address="0x11">
         This register reports status for the overall Debug Module as well as
-        the currently selected harts, as defined in \Fhasel.  Its address will
-        not change in the future, because it contains \Fversion.
+        the currently selected harts, as defined in \FdmDmcontrolHasel.  Its address will
+        not change in the future, because it contains \FdmDmstatusVersion.
 
         <field name="0" bits="31:23" access="R" reset="0" />
         <field name="impebreak" bits="22" access="R" reset="Preset">
@@ -14,7 +14,7 @@
             the debugger from having to write the {\tt ebreak} itself, and
             allows the Program Buffer to be one word smaller.
 
-            This must be 1 when \Fprogbufsize is 1.
+            This must be 1 when \FdmAbstractcsProgbufsize is 1.
         </field>
         <field name="0" bits="21:20" access="R" reset="0" />
         <field name="allhavereset" bits="19" access="R" reset="-">
@@ -71,24 +71,24 @@
         </field>
         <field name="authbusy" bits="6" access="R" reset="0">
             0: The authentication module is ready to process the next
-            read/write to \Rauthdata.
+            read/write to \RdmAuthdata.
 
-            1: The authentication module is busy. Accessing \Rauthdata results
+            1: The authentication module is busy. Accessing \RdmAuthdata results
             in unspecified behavior.
 
-            \Fauthbusy only becomes set in immediate response to an access to
-            \Rauthdata.
+            \FdmDmstatusAuthbusy only becomes set in immediate response to an access to
+            \RdmAuthdata.
         </field>
         <field name="hasresethaltreq" bits="5" reset="Preset" access="R">
             1 if this Debug Module supports halt-on-reset functionality
-            controllable by the \Fsetresethaltreq and \Fclrresethaltreq bits.
+            controllable by the \FdmDmcontrolSetresethaltreq and \FdmDmcontrolClrresethaltreq bits.
             0 otherwise.
         </field>
         <field name="confstrptrvalid" bits="4" reset="Preset" access="R">
-            0: \Rconfstrptrzero--\Rconfstrptrthree hold information which
+            0: \RdmConfstrptrZero--\RdmConfstrptrThree hold information which
             is not relevant to the configuration string.
 
-            1: \Rconfstrptrzero--\Rconfstrptrthree hold the address of the
+            1: \RdmConfstrptrZero--\RdmConfstrptrThree hold the address of the
             configuration string.
         </field>
         <field name="version" bits="3:0" reset="2" access="R">
@@ -107,12 +107,12 @@
 
     <register name="Debug Module Control" short="dmcontrol" address="0x10">
         This register controls the overall Debug Module
-        as well as the currently selected harts, as defined in \Fhasel.
+        as well as the currently selected harts, as defined in \FdmDmcontrolHasel.
 
 \label{hartsel}
 \index{hartsel}
-        Throughout this document we refer to \Fhartsel, which is \Fhartselhi
-        combined with \Fhartsello. While the spec allows for 20 \Fhartsel bits,
+        Throughout this document we refer to \Fhartsel, which is \FdmDmcontrolHartselhi
+        combined with \FdmDmcontrolHartsello. While the spec allows for 20 \Fhartsel bits,
         an implementation may choose to implement fewer than that. The actual
         width of \Fhartsel is called {\tt HARTSELLEN}. It must be at least 0
         and at most 20. A debugger should discover {\tt HARTSELLEN} by writing
@@ -121,23 +121,23 @@
         \Fhartsel while an abstract command is executing.
 
         \begin{commentary}
-        There are separate \Fsetresethaltreq and \Fclrresethaltreq bits so that
-        it is possible to write \Rdmcontrol without changing the halt-on-reset
+        There are separate \FdmDmcontrolSetresethaltreq and \FdmDmcontrolClrresethaltreq bits so that
+        it is possible to write \RdmDmcontrol without changing the halt-on-reset
         request bit for each selected hart, when not all selected harts have
         the same configuration.
         \end{commentary}
 
         On any given write, a debugger may only write 1 to at most one of the
-        following bits: \Fresumereq, \Fhartreset, \Fackhavereset,
-        \Fsetresethaltreq, and \Fclrresethaltreq. The others must be written 0.
+        following bits: \FdmDmcontrolResumereq, \FdmDmcontrolHartreset, \FdmDmcontrolAckhavereset,
+        \FdmDmcontrolSetresethaltreq, and \FdmDmcontrolClrresethaltreq. The others must be written 0.
 
 \label{resethaltreq}
 \index{resethaltreq}
         \Fresethaltreq is an optional internal bit of per-hart state that cannot be
-        read, but can be written with \Fsetresethaltreq and \Fclrresethaltreq.
+        read, but can be written with \FdmDmcontrolSetresethaltreq and \FdmDmcontrolClrresethaltreq.
 
-        For forward compatibility, \Fversion will always be readable when bit 1
-        (\Fndmreset) is 0 and bit 0 (\Fdmactive) is 1.
+        For forward compatibility, \FdmDmstatusVersion will always be readable when bit 1
+        (\FdmDmcontrolNdmreset) is 0 and bit 0 (\FdmDmcontrolDmactive) is 1.
 
         <!-- Fields that apply to all selected hart(s) -->
         <field name="haltreq" bits="31" access="W" reset="-">
@@ -148,16 +148,16 @@
             harts. Running harts will halt whenever their halt request bit is
             set.
 
-            Writes apply to the new value of \Fhartsel and \Fhasel.
+            Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
         <field name="resumereq" bits="30" access="W1" reset="-">
             Writing 1 causes the currently selected harts to resume once, if
             they are halted when the write occurs. It also clears the resume
             ack bit for those harts.
 
-            \Fresumereq is ignored if \Fhaltreq is set.
+            \FdmDmcontrolResumereq is ignored if \FdmDmcontrolHaltreq is set.
 
-            Writes apply to the new value of \Fhartsel and \Fhasel.
+            Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
         <field name="hartreset" bits="29" access="R/W" reset="0">
             This optional field writes the reset bit for all the currently
@@ -171,14 +171,14 @@
             after writing 1 the debugger can read the register back to see if
             the feature is supported.
 
-            Writes apply to the new value of \Fhartsel and \Fhasel.
+            Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
         <field name="ackhavereset" bits="28" access="W1" reset="-">
             0: No effect.
 
             1: Clears {\tt havereset} for any selected harts.
 
-            Writes apply to the new value of \Fhartsel and \Fhasel.
+            Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
         <field name="0" bits="27" access="R" reset="0" />
         <field name="hasel" bits="26" access="R/W" reset="0">
@@ -206,21 +206,21 @@
         <field name="0" bits="5:4" access="R" reset="0" />
         <field name="setresethaltreq" bits="3" access="W1" reset="-">
             This optional field writes the halt-on-reset request bit for all
-            currently selected harts, unless \Fclrresethaltreq is
+            currently selected harts, unless \FdmDmcontrolClrresethaltreq is
             simultaneously set to 1.
             When set to 1, each selected hart will halt upon the next deassertion
             of its reset. The halt-on-reset request bit is not automatically
-            cleared. The debugger must write to \Fclrresethaltreq to clear it.
+            cleared. The debugger must write to \FdmDmcontrolClrresethaltreq to clear it.
 
-            Writes apply to the new value of \Fhartsel and \Fhasel.
+            Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
 
-            If \Fhasresethaltreq is 0, this field is not implemented.
+            If \FdmDmstatusHasresethaltreq is 0, this field is not implemented.
         </field>
         <field name="clrresethaltreq" bits="2" access="W1" reset="-">
             This optional field clears the halt-on-reset request bit for all
             currently selected harts.
 
-            Writes apply to the new value of \Fhartsel and \Fhasel.
+            Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
         <!-- Fields that apply to the entire DM. -->
         <field name="ndmreset" bits="1" access="R/W" reset="0">
@@ -236,9 +236,9 @@
             This bit serves as a reset signal for the Debug Module itself.
 
             0: The module's state, including authentication mechanism,
-            takes its reset values (the \Fdmactive bit is the only bit which can
+            takes its reset values (the \FdmDmcontrolDmactive bit is the only bit which can
             be written to something other than its reset value). Any accesses
-            to the module may fail. Specifically, \Fversion may not return
+            to the module may fail. Specifically, \FdmDmstatusVersion may not return
             correct data.
 
             1: The module functions normally.
@@ -272,7 +272,7 @@
         <field name="0" bits="31:24" access="R" reset="0" />
         <field name="nscratch" bits="23:20" access="R" reset="Preset">
             Number of {\tt dscratch} registers available for the debugger
-            to use during program buffer execution, starting from \Rdscratchzero.
+            to use during program buffer execution, starting from \RcsrDscratchZero.
             The debugger can make no assumptions about the contents of these
             registers between commands.
         </field>
@@ -286,20 +286,20 @@
             Each register takes up 4 bytes in the memory map.
         </field>
         <field name="datasize" bits="15:12" access="R" reset="Preset">
-            If \Fdataaccess is 0: Number of CSRs dedicated to
+            If \FdmHartinfoDataaccess is 0: Number of CSRs dedicated to
             shadowing the {\tt data} registers.
 
-            If \Fdataaccess is 1: Number of 32-bit words in the memory map
+            If \FdmHartinfoDataaccess is 1: Number of 32-bit words in the memory map
             dedicated to shadowing the {\tt data} registers.
 
             Since there are at most 12 {\tt data} registers, the value in this
             register must be 12 or smaller.
         </field>
         <field name="dataaddr" bits="11:0" access="R" reset="Preset">
-            If \Fdataaccess is 0: The number of the first CSR dedicated to
+            If \FdmHartinfoDataaccess is 0: The number of the first CSR dedicated to
             shadowing the {\tt data} registers.
 
-            If \Fdataaccess is 1: Signed address of RAM where the {\tt data}
+            If \FdmHartinfoDataaccess is 1: Signed address of RAM where the {\tt data}
             registers are shadowed, to be used to access relative to \Rzero.
         </field>
     </register>
@@ -308,7 +308,7 @@
 
     <register name="Hart Array Window Select" short="hawindowsel" address="0x14">
       This register selects which of the 32-bit portion of the hart array mask
-      register (see Section~\ref{hartarraymask}) is accessible in \Rhawindow.
+      register (see Section~\ref{hartarraymask}) is accessible in \RdmHawindow.
 
       <field name="0" bits="31:15" access="R/W" reset="0" />
       <field name="hawindowsel" bits="14:0" access="R/W" reset="0">
@@ -321,13 +321,13 @@
     <register name="Hart Array Window " short="hawindow" address="0x15">
       This register provides R/W access to a 32-bit portion of the
       hart array mask register (see Section~\ref{hartarraymask}).
-      The position of the window is determined by \Rhawindowsel. I.e. bit 0
-      refers to hart $\Rhawindowsel * 32$, while bit 31 refers to hart
-      $\Rhawindowsel * 32 + 31$.
+      The position of the window is determined by \RdmHawindowsel. I.e. bit 0
+      refers to hart $\RdmHawindowsel * 32$, while bit 31 refers to hart
+      $\RdmHawindowsel * 32 + 31$.
 
       Since some bits in the hart array mask register may be constant 0, some
       bits in this register may be constant 0, depending on the current value
-      of \Fhawindowsel.
+      of \FdmHawindowselHawindowsel.
       <field name="maskdata" bits="31:0" access="R/W" reset="0" />
     </register>
 
@@ -335,10 +335,10 @@
 
     <register name="Abstract Control and Status" short="abstractcs" address="0x16">
         Writing this register while an abstract command is executing causes
-        \Fcmderr to be set to 1 (busy) if it is 0.
+        \FdmAbstractcsCmderr to be set to 1 (busy) if it is 0.
 
         \begin{commentary}
-            \Fdatacount must be at least 1 to support RV32 harts, 2 to support
+            \FdmAbstractcsDatacount must be at least 1 to support RV32 harts, 2 to support
             RV64 harts, or 4 to support RV128 harts.
         \end{commentary}
 
@@ -350,7 +350,7 @@
         <field name="busy" bits="12" access="R" reset="0">
             1: An abstract command is currently being executed.
 
-            This bit is set as soon as \Rcommand is written, and is
+            This bit is set as soon as \RdmCommand is written, and is
             not cleared until that command has completed.
         </field>
         <field name="0" bits="11" access="R" reset="0" />
@@ -359,16 +359,16 @@
             they are cleared by writing 1 to them. No abstract command is
             started until the value is reset to 0.
 
-            This field only contains a valid value if \Fbusy is 0.
+            This field only contains a valid value if \FdmAbstractcsBusy is 0.
 
             0 (none): No error.
 
-            1 (busy): An abstract command was executing while \Rcommand,
-            \Rabstractcs, or \Rabstractauto was written, or when one
+            1 (busy): An abstract command was executing while \RdmCommand,
+            \RdmAbstractcs, or \RdmAbstractauto was written, or when one
             of the {\tt data} or {\tt progbuf} registers was read or written.
-            This status is only written if \Fcmderr contains 0.
+            This status is only written if \FdmAbstractcsCmderr contains 0.
 
-            2 (not supported): The command in \Rcommand is not supported.  It
+            2 (not supported): The command in \RdmCommand is not supported.  It
             may be supported with different options set, but it will not be
             supported at a later time when the hart or system state are
             different.
@@ -396,15 +396,15 @@
         executed.
 
         Writing this register while an abstract command is executing causes
-        \Fcmderr to be set to 1 (busy) if it is 0.
+        \FdmAbstractcsCmderr to be set to 1 (busy) if it is 0.
 
-        If \Fcmderr is non-zero, writes to this register are ignored.
+        If \FdmAbstractcsCmderr is non-zero, writes to this register are ignored.
 
         \begin{commentary}
-            \Fcmderr inhibits starting a new command to accommodate debuggers
+            \FdmAbstractcsCmderr inhibits starting a new command to accommodate debuggers
             that, for performance reasons, send several commands to be executed
-            in a row without checking \Fcmderr in between. They can safely do
-            so and check \Fcmderr at the end without worrying that one command
+            in a row without checking \FdmAbstractcsCmderr in between. They can safely do
+            so and check \FdmAbstractcsCmderr at the end without worrying that one command
             failed but then a later command (which might have depended on the
             previous one succeeding) passed.
         \end{commentary}
@@ -425,23 +425,23 @@
         and reading them back.
 
         Writing this register while an abstract command is executing causes
-        \Fcmderr to be set to 1 (busy) if it is 0.
+        \FdmAbstractcsCmderr to be set to 1 (busy) if it is 0.
 
         <field name="autoexecprogbuf" bits="31:16" access="R/W" reset="0">
             When a bit in this field is 1, read or write accesses to the
-            corresponding {\tt progbuf} word cause the command in \Rcommand to
+            corresponding {\tt progbuf} word cause the command in \RdmCommand to
             be executed again.
         </field>
         <field name="0" bits ="15:12" access="R" reset = "0"/>
         <field name="autoexecdata" bits="11:0" access="R/W" reset="0">
             When a bit in this field is 1, read or write accesses to the
-            corresponding {\tt data} word cause the command in \Rcommand to be
+            corresponding {\tt data} word cause the command in \RdmCommand to be
             executed again.
         </field>
     </register>
 
     <register name="Configuration String Pointer 0" short="confstrptr0" address="0x19">
-      When \Fconfstrptrvalid is set, reading this register returns bits 31:0
+      When \FdmDmstatusConfstrptrvalid is set, reading this register returns bits 31:0
       of the configuration string pointer. Reading the other {\tt confstrptr}
       registers returns the upper bits of the address.
 
@@ -450,7 +450,7 @@
       this must be an address that can be used to access the
       configuration string from the hart with ID 0.
 
-      If \Fconfstrptrvalid is 0, then the {\tt confstrptr} registers
+      If \FdmDmstatusConfstrptrvalid is 0, then the {\tt confstrptr} registers
       hold identifier information which is not
       further specified in this document.
 
@@ -470,16 +470,16 @@
     </register>
 
     <register name="Abstract Data 0" short="data0" address="0x04">
-        \Rdatazero through \Rdataeleven are basic read/write registers that may
-        be read or changed by abstract commands. \Fdatacount indicates how many
-        of them are implemented, starting at \Rdatazero, counting up.
+        \RdmDataZero through \RdmDataEleven are basic read/write registers that may
+        be read or changed by abstract commands. \FdmAbstractcsDatacount indicates how many
+        of them are implemented, starting at \RdmDataZero, counting up.
         Table~\ref{tab:datareg} shows how abstract commands use these
         registers.
 
         Accessing these registers while an abstract command is executing causes
-        \Fcmderr to be set to 1 (busy) if it is 0.
+        \FdmAbstractcsCmderr to be set to 1 (busy) if it is 0.
 
-        Attempts to write them while \Fbusy is set does not change their value.
+        Attempts to write them while \FdmAbstractcsBusy is set does not change their value.
 
         The values in these registers may not be preserved after an abstract
         command is executed. The only guarantees on their contents are the ones
@@ -505,14 +505,14 @@
     <!-- =============== Program Buffer =============== -->
 
     <register name="Program Buffer 0" short="progbuf0" address="0x20">
-        \Rprogbufzero through \Rprogbuffifteen provide read/write access to the
-        optional program buffer. \Fprogbufsize indicates how many of them are
-        implemented starting at \Rprogbufzero, counting up.
+        \RdmProgbufZero through \RdmProgbufFifteen provide read/write access to the
+        optional program buffer. \FdmAbstractcsProgbufsize indicates how many of them are
+        implemented starting at \RdmProgbufZero, counting up.
 
         Accessing these registers while an abstract command is executing causes
-        \Fcmderr to be set to 1 (busy) if it is 0.
+        \FdmAbstractcsCmderr to be set to 1 (busy) if it is 0.
 
-        Attempts to write them while \Fbusy is set does not change their value.
+        Attempts to write them while \FdmAbstractcsBusy is set does not change their value.
 
         <field name="data" bits="31:0" access="R/W" reset="0" />
     </register>
@@ -540,7 +540,7 @@
         This register serves as a 32-bit serial port to/from the authentication
         module.
 
-        When \Fauthbusy is clear, the debugger can communicate with the
+        When \FdmDmstatusAuthbusy is clear, the debugger can communicate with the
         authentication module by reading or writing this register. There is no
         separate mechanism to signal overflow/underflow.
 
@@ -549,7 +549,7 @@
 
     <register name="Debug Module Control and Status 2" short="dmcs2" address="0x32">
         This register contains DM control and status bits that didn't easily
-        fit in \Rdmcontrol and \Rdmstatus. All are optional.
+        fit in \RdmDmcontrol and \RdmDmstatus. All are optional.
 
         <field name="0" bits="31:11" access="R" reset="0" />
         <field name="exttrigger" bits="10:7" access="WARL" reset="0">
@@ -559,25 +559,25 @@
             change it to a valid one or 0 if no external triggers exist.
         </field>
         <field name="haltgroup" bits="6:2" access="WARL" reset="0">
-            When \Fhgselect is 0, contains the halt group of the hart
+            When \FdmDmcsTwoHgselect is 0, contains the halt group of the hart
             specified by \Fhartsel.
 
-            When \Fhgselect is 1, contains the halt group of the external
-            trigger selected by \Fexttrigger.
+            When \FdmDmcsTwoHgselect is 1, contains the halt group of the external
+            trigger selected by \FdmDmcsTwoExttrigger.
 
-            Writes only have an effect if \Fhgwrite is also written 1.
+            Writes only have an effect if \FdmDmcsTwoHgwrite is also written 1.
 
             An implementation may tie any number of upper bits in this field to
             0. If halt groups aren't implemented, then this entire field
             is 0.
         </field>
         <field name="hgwrite" bits="1" access="W" reset="-">
-            When \Fhgselect is 0, writing 1 changes the halt group of all
-            selected harts to the value written to \Fhaltgroup.
+            When \FdmDmcsTwoHgselect is 0, writing 1 changes the halt group of all
+            selected harts to the value written to \FdmDmcsTwoHaltgroup.
 
-            When \Fhgselect is 1, writing 1 changes the halt group of the
-            external trigger selected by \Fexttrigger to the value written to
-            \Fhaltgroup.
+            When \FdmDmcsTwoHgselect is 1, writing 1 changes the halt group of the
+            external trigger selected by \FdmDmcsTwoExttrigger to the value written to
+            \FdmDmcsTwoHaltgroup.
 
             Writing 0 has no effect.
         </field>
@@ -662,7 +662,7 @@
         <field name="sbbusyerror" bits="22" access="R/W1C" reset="0">
             Set when the debugger attempts to read data while a read is in
             progress, or when the debugger initiates a new access while one is
-            already in progress (while \Fsbbusy is set). It remains set until
+            already in progress (while \FdmSbcsSbbusy is set). It remains set until
             it's explicitly cleared by the debugger.
 
             While this field is set, no more system bus accesses can be
@@ -674,12 +674,12 @@
             bit goes high immediately when a read or write is requested for any
             reason, and does not go low until the access is fully completed.
 
-            Writes to \Rsbcs while \Fsbbusy is high result in undefined
-            behavior.  A debugger must not write to \Rsbcs until it reads
-            \Fsbbusy as 0.
+            Writes to \RdmSbcs while \FdmSbcsSbbusy is high result in undefined
+            behavior.  A debugger must not write to \RdmSbcs until it reads
+            \FdmSbcsSbbusy as 0.
         </field>
         <field name="sbreadonaddr" bits="20" access="R/W" reset="0">
-            When 1, every write to \Rsbaddresszero automatically triggers a
+            When 1, every write to \RdmSbaddressZero automatically triggers a
             system bus read at the new address.
         </field>
         <field name="sbaccess" bits="19:17" access="R/W" reset="2">
@@ -695,15 +695,15 @@
 
             4: 128-bit
 
-            If \Fsbaccess has an unsupported value when the DM starts a bus
-            access, the access is not performed and \Fsberror is set to 4.
+            If \FdmSbcsSbaccess has an unsupported value when the DM starts a bus
+            access, the access is not performed and \FdmSbcsSberror is set to 4.
         </field>
         <field name="sbautoincrement" bits="16" access="R/W" reset="0">
             When 1, {\tt sbaddress} is incremented by the access size (in
-            bytes) selected in \Fsbaccess after every system bus access.
+            bytes) selected in \FdmSbcsSbaccess after every system bus access.
         </field>
         <field name="sbreadondata" bits="15" access="R/W" reset="0">
-            When 1, every read from \Rsbdatazero automatically triggers a
+            When 1, every read from \RdmSbdataZero automatically triggers a
             system bus read at the (possibly auto-incremented) address.
         </field>
         <field name="sberror" bits="14:12" access="R/W1C" reset="0">
@@ -749,18 +749,18 @@
     </register>
 
     <register name="System Bus Address 31:0" short="sbaddress0" address="0x39">
-        If \Fsbasize is 0, then this register is not present.
+        If \FdmSbcsSbasize is 0, then this register is not present.
 
         When the system bus master is busy, writes to this register will set
-        \Fsbbusyerror and don't do anything else.
+        \FdmSbcsSbbusyerror and don't do anything else.
 
-        \begin{steps}{If \Fsberror is 0, \Fsbbusyerror is 0, and \Fsbreadonaddr
+        \begin{steps}{If \FdmSbcsSberror is 0, \FdmSbcsSbbusyerror is 0, and \FdmSbcsSbreadonaddr
         is set then writes to this register start the following:}
-            \item Set \Fsbbusy.
+            \item Set \FdmSbcsSbbusy.
             \item Perform a bus read from the new value of {\tt sbaddress}.
-            \item If the read succeeded and \Fsbautoincrement is set, increment
+            \item If the read succeeded and \FdmSbcsSbautoincrement is set, increment
             {\tt sbaddress}.
-            \item Clear \Fsbbusy.
+            \item Clear \FdmSbcsSbbusy.
         \end{steps}
 
         <field name="address" bits="31:0" access="R/W" reset="0">
@@ -769,10 +769,10 @@
     </register>
 
     <register name="System Bus Address 63:32" short="sbaddress1" address="0x3a">
-        If \Fsbasize is less than 33, then this register is not present.
+        If \FdmSbcsSbasize is less than 33, then this register is not present.
 
         When the system bus master is busy, writes to this register will set
-        \Fsbbusyerror and don't do anything else.
+        \FdmSbcsSbbusyerror and don't do anything else.
 
         <field name="address" bits="31:0" access="R/W" reset="0">
             Accesses bits 63:32 of the physical address in {\tt sbaddress} (if
@@ -781,10 +781,10 @@
     </register>
 
     <register name="System Bus Address 95:64" short="sbaddress2" address="0x3b">
-        If \Fsbasize is less than 65, then this register is not present.
+        If \FdmSbcsSbasize is less than 65, then this register is not present.
 
         When the system bus master is busy, writes to this register will set
-        \Fsbbusyerror and don't do anything else.
+        \FdmSbcsSbbusyerror and don't do anything else.
 
         <field name="address" bits="31:0" access="R/W" reset="0">
             Accesses bits 95:64 of the physical address in {\tt sbaddress} (if
@@ -793,10 +793,10 @@
     </register>
 
     <register name="System Bus Address 127:96" short="sbaddress3" address="0x37">
-        If \Fsbasize is less than 97, then this register is not present.
+        If \FdmSbcsSbasize is less than 97, then this register is not present.
 
         When the system bus master is busy, writes to this register will set
-        \Fsbbusyerror and don't do anything else.
+        \FdmSbcsSbbusyerror and don't do anything else.
 
         <field name="address" bits="31:0" access="R/W" reset="0">
             Accesses bits 127:96 of the physical address in {\tt sbaddress} (if
@@ -805,39 +805,39 @@
     </register>
 
     <register name="System Bus Data 31:0" short="sbdata0" address="0x3c">
-        If all of the {\tt sbaccess} bits in \Rsbcs are 0, then this register
+        If all of the {\tt sbaccess} bits in \RdmSbcs are 0, then this register
         is not present.
 
         Any successful system bus read updates {\tt sbdata}. If the width of
         the read access is less than the width of {\tt sbdata}, the contents of
         the remaining high bits may take on any value.
 
-        If either \Fsberror or \Fsbbusyerror isn't 0 then accesses do nothing.
+        If either \FdmSbcsSberror or \FdmSbcsSbbusyerror isn't 0 then accesses do nothing.
 
-        If the bus master is busy then accesses set \Fsbbusyerror, and don't do
+        If the bus master is busy then accesses set \FdmSbcsSbbusyerror, and don't do
         anything else.
 
         \begin{steps}{Writes to this register start the following:}
-            \item Set \Fsbbusy.
+            \item Set \FdmSbcsSbbusy.
             \item Perform a bus write of the new value of {\tt sbdata} to {\tt sbaddress}.
-            \item If the write succeeded and \Fsbautoincrement is set,
+            \item If the write succeeded and \FdmSbcsSbautoincrement is set,
             increment {\tt sbaddress}.
-            \item Clear \Fsbbusy.
+            \item Clear \FdmSbcsSbbusy.
         \end{steps}
 
         \begin{steps}{Reads from this register start the following:}
             \item ``Return'' the data.
-            \item Set \Fsbbusy.
-            \item If \Fsbreadondata is set, perform a system bus read from the
+            \item Set \FdmSbcsSbbusy.
+            \item If \FdmSbcsSbreadondata is set, perform a system bus read from the
             address contained in {\tt sbaddress}, placing the result in {\tt
             sbdata}.
-            \item If \Fsbautoincrement is set, increment {\tt sbaddress}.
-            \item Clear \Fsbbusy.
+            \item If \FdmSbcsSbautoincrement is set, increment {\tt sbaddress}.
+            \item Clear \FdmSbcsSbbusy.
         \end{steps}
 
-        Only \Rsbdatazero has this behavior. The other {\tt sbdata} registers
+        Only \RdmSbdataZero has this behavior. The other {\tt sbdata} registers
         have no side effects. On systems that have buses wider than 32 bits, a
-        debugger should access \Rsbdatazero after accessing the other {\tt
+        debugger should access \RdmSbdataZero after accessing the other {\tt
         sbdata} registers.
 
         <field name="data" bits="31:0" access="R/W" reset="0">
@@ -846,10 +846,10 @@
     </register>
 
     <register name="System Bus Data 63:32" short="sbdata1" address="0x3d">
-        If \Fsbaccesssixtyfour and \Fsbaccessonetwentyeight are 0, then this
+        If \FdmSbcsSbaccessSixtyfour and \FdmSbcsSbaccessOneTwentyeight are 0, then this
         register is not present.
 
-        If the bus master is busy then accesses set \Fsbbusyerror, and don't do
+        If the bus master is busy then accesses set \FdmSbcsSbbusyerror, and don't do
         anything else.
 
         <field name="data" bits="31:0" access="R/W" reset="0">
@@ -859,9 +859,9 @@
     </register>
 
     <register name="System Bus Data 95:64" short="sbdata2" address="0x3e">
-        This register only exists if \Fsbaccessonetwentyeight is 1.
+        This register only exists if \FdmSbcsSbaccessOneTwentyeight is 1.
 
-        If the bus master is busy then accesses set \Fsbbusyerror, and don't do
+        If the bus master is busy then accesses set \FdmSbcsSbbusyerror, and don't do
         anything else.
 
         <field name="data" bits="31:0" access="R/W" reset="0">
@@ -871,9 +871,9 @@
     </register>
 
     <register name="System Bus Data 127:96" short="sbdata3" address="0x3f">
-        This register only exists if \Fsbaccessonetwentyeight is 1.
+        This register only exists if \FdmSbcsSbaccessOneTwentyeight is 1.
 
-        If the bus master is busy then accesses set \Fsbbusyerror, and don't do
+        If the bus master is busy then accesses set \FdmSbcsSbbusyerror, and don't do
         anything else.
 
         <field name="data" bits="31:0" access="R/W" reset="0">

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -4,12 +4,12 @@
     OS's permission.
 
     In this section XLEN means MXLEN when in M-mode, and DXLEN when in Debug Mode.
-    Note that this makes several of the fields in \Rtdataone move around based
+    Note that this makes several of the fields in \RcsrTdataOne move around based
     on the current execution mode and value of MXLEN.
 
     \begin{table}[H]
     \centering
-    \caption{\Faction encoding}
+    \caption{\FcsrMcontrolAction encoding}
     \label{tab:action}
     \begin{tabular}{|r|L|}
     \hline
@@ -18,7 +18,7 @@
     0 &amp; Raise a breakpoint exception. (Used when software wants to use the
     trigger module without an external debugger attached.) \\
     \hline
-    1 &amp; Enter Debug Mode. (Only supported when the trigger's \Fdmode is 1.)
+    1 &amp; Enter Debug Mode. (Only supported when the trigger's \FcsrTdataOneDmode is 1.)
     \\
     \hline
     2 -- 5 &amp; Reserved for use by the trace specification. \\
@@ -36,7 +36,7 @@
         Writes of values greater than or equal to the number of supported
         triggers may result in a different value in this register than what was
         written. To verify that what they wrote is a valid index, debuggers can
-        read back the value and check that \Rtselect holds what they wrote.
+        read back the value and check that \RcsrTselect holds what they wrote.
 
         Since triggers can be used both by Debug Mode and M-mode, the debugger
         must restore this register if it modifies it.
@@ -48,22 +48,22 @@
         This register is optional if no triggers are implemented.
 
         <field name="type" bits="XLEN-1:XLEN-4" access="R/W" reset="Preset">
-            0: There is no trigger at this \Rtselect.
+            0: There is no trigger at this \RcsrTselect.
 
             1: The trigger is a legacy SiFive address match trigger. These
             should not be implemented and aren't further documented here.
 
             2: The trigger is an address/data match trigger. The remaining bits
-            in this register act as described in \Rmcontrol.
+            in this register act as described in \RcsrMcontrol.
 
             3: The trigger is an instruction count trigger. The remaining bits
-            in this register act as described in \Ricount.
+            in this register act as described in \RcsrIcount.
 
             4: The trigger is an interrupt trigger. The remaining bits
-            in this register act as described in \Ritrigger.
+            in this register act as described in \RcsrItrigger.
 
             5: The trigger is an exception trigger. The remaining bits
-            in this register act as described in \Retrigger.
+            in this register act as described in \RcsrEtrigger.
 
             12--14: These trigger types are available for non-standard use.
 
@@ -74,10 +74,10 @@
         </field>
         <field name="dmode" bits="XLEN-5" access="R/W" reset="0">
             0: Both Debug and M-mode can write the {\tt tdata} registers at the
-            selected \Rtselect.
+            selected \RcsrTselect.
 
             1: Only Debug Mode can write the {\tt tdata} registers at the
-            selected \Rtselect.  Writes from other modes are ignored.
+            selected \RcsrTselect.  Writes from other modes are ignored.
 
             This bit is only writable from Debug Mode.
         </field>
@@ -103,13 +103,13 @@
     </register>
 
     <register name="Trigger Info" short="tinfo" address="0x7a4">
-        This register is optional if no triggers are implemented, or if \Ftype
+        This register is optional if no triggers are implemented, or if \FcsrTdataOneType
         is not writable. In this case the debugger can read the only supported
-        type from \Rtdataone.
+        type from \RcsrTdataOne.
 
         <field name="0" bits="XLEN-1:16" access="R" reset="0" />
         <field name="info" bits="15:0" access="R" reset="Preset">
-            One bit for each possible \Ftype enumerated in \Rtdataone. Bit N
+            One bit for each possible \FcsrTdataOneType enumerated in \RcsrTdataOne. Bit N
             corresponds to type N. If the bit is set, then that type is
             supported by the currently selected trigger.
 
@@ -127,8 +127,8 @@
         <field name="mpte" bits="7" access="R/W" reset="0">
             M-mode previous trigger enable field.
 
-            When a trap into M-mode is taken, \Fmpte is set to the value of
-            \Fmte.
+            When a trap into M-mode is taken, \FcsrTcontrolMpte is set to the value of
+            \FcsrTcontrolMte.
         </field>
         <field name="0" bits="6:4" access="R" reset="0" />
         <field name="mte" bits="3" access="R/W" reset="0">
@@ -138,8 +138,8 @@
 
             1: Triggers do match/fire while the hart is in M-mode.
 
-            When a trap into M-mode is taken, \Fmte is set to 0. When {\tt
-            mret} is executed, \Fmte is set to the value of \Fmpte.
+            When a trap into M-mode is taken, \FcsrTcontrolMte is set to 0. When {\tt
+            mret} is executed, \FcsrTcontrolMte is set to the value of \FcsrTcontrolMpte.
         </field>
         <field name="0" bits="2:0" access="R" reset="0" />
     </register>
@@ -173,13 +173,13 @@
     </register>
 
     <register name="Match Control" short="mcontrol" address="0x7a1">
-        This register is accessible as \Rtdataone when \Ftype is 2.
+        This register is accessible as \RcsrTdataOne when \FcsrTdataOneType is 2.
 
         Address and data trigger implementation are heavily dependent on how
         the processor core is implemented. To accommodate various
         implementations, execute, load, and store address/data triggers may fire at
         whatever point in time is most convenient for the implementation.
-        The debugger may request specific timings as described in \Ftiming.
+        The debugger may request specific timings as described in \FcsrMcontrolTiming.
         Table~\ref{tab:hwbp_timing} suggests timings for the best user experience.
 
         \begin{table}[H]
@@ -203,8 +203,8 @@
         \end{tabular}
         \end{table}
 
-        This trigger type may be limited to address comparisons (\Fselect is
-        always 0) only. If that is the case, then \Rtdatatwo must be able to
+        This trigger type may be limited to address comparisons (\FcsrMcontrolSelect is
+        always 0) only. If that is the case, then \RcsrTdataTwo must be able to
         hold all valid virtual addresses but it need not be capable of holding
         other values.
 
@@ -212,7 +212,7 @@
         <field name="dmode" bits="XLEN-5" access="R/W" reset="0" />
         <field name="maskmax" bits="XLEN-6:XLEN-11" access="R" reset="Preset">
             Specifies the largest naturally aligned powers-of-two (NAPOT) range
-            supported by the hardware when \Fmatch is 1. The value is the
+            supported by the hardware when \FcsrMcontrolMatch is 1. The value is the
             logarithm base 2 of the
             number of bytes in that range.  A value of 0 indicates that only
             exact value matches are supported (one byte range). A value of 63
@@ -222,7 +222,7 @@
         <field name="0" bits="XLEN-12:23" access="R" reset="0" />
         <field name="sizehi" bits="22:21" access="R/W" reset="0">
             This field only exists if XLEN is greater than 32. In that case it
-            extends \Fsize. If it does not exist then hardware operates as if
+            extends \FcsrMcontrolSizelo. If it does not exist then hardware operates as if
             the field contains 0.
         </field>
         <field name="hit" bits="20" access="R/W" reset="0">
@@ -253,27 +253,27 @@
             not implement that suggestion than to not implement them at all.
 
             Most hardware will only implement one timing or the other, possibly
-            dependent on \Fselect, \Fexecute, \Fload, and \Fstore. This bit
+            dependent on \FcsrMcontrolSelect, \FcsrMcontrolExecute, \FcsrMcontrolLoad, and \FcsrMcontrolStore. This bit
             primarily exists for the hardware to communicate to the debugger
             what will happen. Hardware may implement the bit fully writable, in
             which case the debugger has a little more control.
 
-            Data load triggers with \Ftiming of 0 will result in the same load
+            Data load triggers with \FcsrMcontrolTiming of 0 will result in the same load
             happening again when the debugger lets the hart run. For data load
             triggers, debuggers must first attempt to set the breakpoint with
-            \Ftiming of 1.
+            \FcsrMcontrolTiming of 1.
 
-            A chain of triggers that don't all have the same \Ftiming value
+            A chain of triggers that don't all have the same \FcsrMcontrolTiming value
             will never fire (unless consecutive instructions match the
             appropriate triggers).
 
-            If a trigger with \Ftiming of 0 matches, it is
+            If a trigger with \FcsrMcontrolTiming of 0 matches, it is
             implementation-dependent whether that prevents a trigger with
-            \Ftiming of 1 matching as well.
+            \FcsrMcontrolTiming of 1 matching as well.
         </field>
         <field name="sizelo" bits="17:16" access="R/W" reset="0">
-            This field contains the 2 low bits of \Fsize. The high bits come
-            from \Fsizehi. The combined value is interpreted as follows:
+            This field contains the 2 low bits of the access size. The high bits come
+            from \FcsrMcontrolSizehi. The combined value is interpreted as follows:
 
             0: The trigger will attempt to match against an access of any size.
             The behavior is only well-defined if $|select|=0$, or if the access
@@ -319,39 +319,39 @@
             trigger will be taken if and only if all the triggers in the chain
             match at the same time.
 
-            Because \Fchain affects the next trigger, hardware must zero it in
-            writes to \Rmcontrol that set \Fdmode to 0 if the next trigger has
-            \Fdmode of 1.
-            In addition hardware should ignore writes to \Rmcontrol that set
-            \Fdmode to 1 if the previous trigger has both \Fdmode of 0 and
-            \Fchain of 1. Debuggers must avoid the latter case by checking
-            \Fchain on the previous trigger if they're writing \Rmcontrol.
+            Because \FcsrMcontrolChain affects the next trigger, hardware must zero it in
+            writes to \RcsrMcontrol that set \FcsrTdataOneDmode to 0 if the next trigger has
+            \FcsrTdataOneDmode of 1.
+            In addition hardware should ignore writes to \RcsrMcontrol that set
+            \FcsrTdataOneDmode to 1 if the previous trigger has both \FcsrTdataOneDmode of 0 and
+            \FcsrMcontrolChain of 1. Debuggers must avoid the latter case by checking
+            \FcsrMcontrolChain on the previous trigger if they're writing \RcsrMcontrol.
 
             Implementations that wish to limit the maximum length of a trigger
             chain (eg. to meet timing requirements) may do so by zeroing
-            \Fchain in writes to \Rmcontrol that would make the chain too long.
+            \FcsrMcontrolChain in writes to \RcsrMcontrol that would make the chain too long.
         </field>
         <field name="match" bits="10:7" access="R/W" reset="0">
-            0: Matches when the value equals \Rtdatatwo.
+            0: Matches when the value equals \RcsrTdataTwo.
 
             1: Matches when the top M bits of the value match the top M bits of
-            \Rtdatatwo. M is XLEN-1 minus the index of the least-significant
-            bit containing 0 in \Rtdatatwo. Debuggers should only write values
-            to \Rtdatatwo such that M + \Fmaskmax $\geq$ XLEN, otherwise it's
+            \RcsrTdataTwo. M is XLEN-1 minus the index of the least-significant
+            bit containing 0 in \RcsrTdataTwo. Debuggers should only write values
+            to \RcsrTdataTwo such that M + \FcsrMcontrolMaskmax $\geq$ XLEN, otherwise it's
             undefined on what conditions the trigger will fire.
 
             2: Matches when the value is greater than (unsigned) or equal to
-            \Rtdatatwo.
+            \RcsrTdataTwo.
 
-            3: Matches when the value is less than (unsigned) \Rtdatatwo.
+            3: Matches when the value is less than (unsigned) \RcsrTdataTwo.
 
             4: Matches when the lower half of the value equals the lower half
-            of \Rtdatatwo after the lower half of the value is ANDed with the
-            upper half of \Rtdatatwo.
+            of \RcsrTdataTwo after the lower half of the value is ANDed with the
+            upper half of \RcsrTdataTwo.
 
             5: Matches when the upper half of the value equals the lower half
-            of \Rtdatatwo after the upper half of the value is ANDed with the
-            upper half of \Rtdatatwo.
+            of \RcsrTdataTwo after the upper half of the value is ANDed with the
+            upper half of \RcsrTdataTwo.
 
             Other values are reserved for future use.
         </field>
@@ -378,18 +378,18 @@
     </register>
 
     <register name="Instruction Count" short="icount" address="0x7a1">
-        This register is accessible as \Rtdataone when \Ftype is 3.
+        This register is accessible as \RcsrTdataOne when \FcsrTdataOneType is 3.
 
         \begin{commentary} This trigger type is intended to be used as a single
         step that's useful both for external debuggers and for software monitor
-        programs. For that case it is not necessary to support \Fcount greater
+        programs. For that case it is not necessary to support \FcsrIcountCount greater
         than
         1. The only two combinations of the mode bits that are useful in those
-        scenarios are \Fu by itself, or \Fm, \Fs, and \Fu all set.
+        scenarios are \FcsrMcontrolU by itself, or \FcsrMcontrolM, \FcsrMcontrolS, and \FcsrMcontrolU all set.
 
-        If the hardware limits \Fcount to 1, and changes mode bits instead of
-        decrementing \Fcount, this register can be implemented with just 2
-        bits. One for \Fu, and one for \Fm and \Fs tied together.  If
+        If the hardware limits \FcsrIcountCount to 1, and changes mode bits instead of
+        decrementing \FcsrIcountCount, this register can be implemented with just 2
+        bits. One for \FcsrMcontrolU, and one for \FcsrMcontrolM and \FcsrMcontrolS tied together.  If
         only the external debugger or only a software monitor needs to be
         supported, a single bit is enough.
         \end{commentary}
@@ -407,22 +407,22 @@
         </field>
         <field name="count" bits="23:10" access="R/W" reset="1">
             When count is decremented to 0, the trigger fires. Instead of
-            changing \Fcount from 1 to 0, it is also acceptable for hardware to
-            clear \Fm, \Fs, and \Fu. This allows \Fcount to be hard-wired
+            changing \FcsrIcountCount from 1 to 0, it is also acceptable for hardware to
+            clear \FcsrMcontrolM, \FcsrMcontrolS, and \FcsrMcontrolU. This allows \FcsrIcountCount to be hard-wired
             to 1 if this register just exists for single step.
         </field>
 
         <field name="m" bits="9" access="R/W" reset="0">
-            When set, every instruction completed or exception taken in M-mode decrements \Fcount
+            When set, every instruction completed or exception taken in M-mode decrements \FcsrIcountCount
             by 1.
         </field>
         <field name="0" bits="8" access="R" reset="0" />
         <field name="s" bits="7" access="R/W" reset="0">
-            When set, every instruction completed or exception taken in S-mode decrements \Fcount
+            When set, every instruction completed or exception taken in S-mode decrements \FcsrIcountCount
             by 1.
         </field>
         <field name="u" bits="6" access="R/W" reset="0">
-            When set, every instruction completed or exception taken in U-mode decrements \Fcount
+            When set, every instruction completed or exception taken in U-mode decrements \FcsrIcountCount
             by 1.
         </field>
 
@@ -433,15 +433,15 @@
     </register>
 
     <register name="Interrupt Trigger" short="itrigger" address="0x7a1">
-        This register is accessible as \Rtdataone when \Ftype is 4.
+        This register is accessible as \RcsrTdataOne when \FcsrTdataOneType is 4.
 
         This trigger may fire on any of the interrupts configurable in \Rmie
         (described in the Privileged Spec). The interrupts to fire on are
-        configured by setting the same bit in \Rtdatatwo as would be set in
+        configured by setting the same bit in \RcsrTdataTwo as would be set in
         \Rmie to enable the interrupt.
 
         Hardware may only support a subset of interrupts for this trigger.  A
-        debugger must read back \Rtdatatwo after writing it to confirm the
+        debugger must read back \RcsrTdataTwo after writing it to confirm the
         requested functionality is actually supported.
 
         The trigger only fires if the hart takes a trap because of the
@@ -482,16 +482,16 @@
     </register>
 
     <register name="Exception Trigger" short="etrigger" address="0x7a1">
-        This register is accessible as \Rtdataone when \Ftype is 5.
+        This register is accessible as \RcsrTdataOne when \FcsrTdataOneType is 5.
 
         This trigger may fire on up to XLEN of the Exception Codes defined in
         \Rmcause (described in the Privileged Spec, with Interrupt=0). Those
-        causes are configured by writing the corresponding bit in \Rtdatatwo.
+        causes are configured by writing the corresponding bit in \RcsrTdataTwo.
         (E.g.\  to trap on an illegal instruction, the debugger sets bit 2 in
-        \Rtdatatwo.)
+        \RcsrTdataTwo.)
 
         Hardware may support only a subset of exceptions. A debugger must read
-        back \Rtdatatwo after writing it to confirm the requested functionality
+        back \RcsrTdataTwo after writing it to confirm the requested functionality
         is actually supported.
 
         When the trigger fires, all CSRs are updated as defined by the
@@ -510,7 +510,7 @@
         <field name="0" bits="XLEN-7:11" access="R" reset="0" />
         <field name="nmi" bits="10" access="R/W" reset="0">
             When this optional bit is set, non-maskable interrupts cause this
-            trigger to fire, regardless of the values of \Fm, \Fs, and \Fu.
+            trigger to fire, regardless of the values of \FcsrMcontrolM, \FcsrMcontrolS, and \FcsrMcontrolU.
         </field>
         <field name="m" bits="9" access="R/W" reset="0">
             When set, enable this trigger for exceptions that are taken from M
@@ -532,7 +532,7 @@
     </register>
 
     <register name="Trigger Extra (RV32)" short="textra32" address="0x7a3">
-        This register is accessible as \Rtdatathree when \Ftype is 2, 3, 4, or
+        This register is accessible as \RcsrTdataThree when \FcsrTdataOneType is 2, 3, 4, or
         5.
 
         All functionality in this register is optional. The $|value|$ bits may
@@ -540,37 +540,37 @@
         0 (ignore).
 
         <field name="mvalue" bits="31:26" access="R/W" reset="0">
-            Data used together with \Fmselect.
+            Data used together with \FcsrTextraThirtytwoMselect.
         </field>
         <field name="mselect" bits="25" access="WARL" reset="0">
-            0: Ignore \Fmvalue.
+            0: Ignore \FcsrTextraThirtytwoMvalue.
 
             1: This trigger will only match if the low bits of
-            \Rmcontext equal \Fmvalue.
+            \RcsrMcontext equal \FcsrTextraThirtytwoMvalue.
         </field>
 
         <field name="0" bits="24:18" access="R" reset="0" />
         <!-- This is space left open for H mode support. -->
 
         <field name="svalue" bits="17:2" access="R/W" reset="0">
-            Data used together with \Fsselect.
+            Data used together with \FcsrTextraThirtytwoSselect.
         </field>
         <field name="sselect" bits="1:0" access="WARL" reset="0">
-            0: Ignore \Fsvalue.
+            0: Ignore \FcsrTextraThirtytwoSvalue.
 
             1: This trigger will only match if the low bits of
-            \Rscontext equal \Fsvalue.
+            \RcsrScontext equal \FcsrTextraThirtytwoSvalue.
 
             2: This trigger will only match if \Fasid in \Rsatp
             equals the lower ASIDMAX (defined in the Privileged Spec) bits of
-            \Fsvalue.
+            \FcsrTextraThirtytwoSvalue.
         </field>
 
     </register>
 
     <register name="Trigger Extra (RV64)" short="textra64" address="0x7a3">
         This is the layout of {\tt textra} if XLEN is 64. The fields are defined
-        above, in \Rtextrathirtytwo.
+        above, in \RcsrTextraThirtytwo.
 
         <field name="mvalue" bits="63:51" access="R/W" reset="0">
         </field>

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -45,8 +45,8 @@
             This is a hint to the debugger of the minimum number of
             cycles a debugger should spend in
             Run-Test/Idle after every DMI scan to avoid a `busy'
-            return code (\Fdmistat of 3). A debugger must still
-            check \Fdmistat when necessary.
+            return code (\FdtmDtmcsDmistat of 3). A debugger must still
+            check \FdtmDtmcsDmistat when necessary.
 
             0: It is not necessary to enter Run-Test/Idle at all.
 
@@ -61,13 +61,13 @@
 
             1: Reserved. Interpret the same as 2.
 
-            2: An operation failed (resulted in \Fop of 2).
+            2: An operation failed (resulted in \FdtmDmiOp of 2).
 
             3: An operation was attempted while a DMI access was still in
-            progress (resulted in \Fop of 3).
+            progress (resulted in \FdtmDmiOp of 3).
         </field>
         <field name="abits" bits="9:4" access="R" reset="Preset">
-            The size of \Faddress in \Rdmi.
+            The size of \FdmSbaddressZeroAddress in \RdtmDmi.
         </field>
         <field name="version" bits="3:0" access="R" reset="1">
             0: Version described in spec version 0.11.
@@ -82,11 +82,11 @@
         sdesc="For Debugging">
         This register allows access to the Debug Module Interface (DMI).
 
-        In Update-DR, the DTM starts the operation specified in \Fop unless the
-        current status reported in \Fop is sticky.
+        In Update-DR, the DTM starts the operation specified in \FdtmDmiOp unless the
+        current status reported in \FdtmDmiOp is sticky.
 
-        In Capture-DR, the DTM updates \Fdata with the result from that
-        operation, updating \Fop if the current \Fop isn't sticky.
+        In Capture-DR, the DTM updates \FdmSbdataZeroData with the result from that
+        operation, updating \FdtmDmiOp if the current \FdtmDmiOp isn't sticky.
 
         See Section~\ref{dmiaccess} and Table~\ref{tab:memread} for examples
         of how this is used.
@@ -112,16 +112,16 @@
         <field name="op" bits="1:0" access="R/W" reset="0">
             When the debugger writes this field, it has the following meaning:
 
-            0: Ignore \Fdata and \Faddress. (nop)
+            0: Ignore \FdmSbdataZeroData and \FdmSbaddressZeroAddress. (nop)
 
             Don't send anything over the DMI during Update-DR.
             This operation should never result in a busy or error response.
             The address and data reported in the following Capture-DR
             are undefined.
 
-            1: Read from \Faddress. (read)
+            1: Read from \FdmSbaddressZeroAddress. (read)
 
-            2: Write \Fdata to \Faddress. (write)
+            2: Write \FdmSbdataZeroData to \FdmSbaddressZeroAddress. (write)
 
             3: Reserved.
 
@@ -131,9 +131,9 @@
 
             1: Reserved.
 
-            2: A previous operation failed.  The data scanned into \Rdmi in
+            2: A previous operation failed.  The data scanned into \RdtmDmi in
             this access will be ignored.  This status is sticky and can be
-            cleared by writing \Fdmireset in \Rdtmcs.
+            cleared by writing \FdtmDtmcsDmireset in \RdtmDtmcs.
 
             This indicates that the DM itself responded with an error.
             There are no specified cases in which the DM would
@@ -141,9 +141,9 @@
             returning errors.
 
             3: An operation was attempted while a DMI request is still in
-            progress. The data scanned into \Rdmi in this access will be
+            progress. The data scanned into \RdtmDmi in this access will be
             ignored. This status is sticky and can be cleared by writing
-            \Fdmireset in \Rdtmcs. If a debugger sees this status, it
+            \FdtmDtmcsDmireset in \RdtmDtmcs. If a debugger sees this status, it
             needs to give the target more TCK edges between Update-DR and
             Capture-DR. The simplest way to do that is to add extra transitions
             in Run-Test/Idle.

--- a/xml/serial.xml
+++ b/xml/serial.xml
@@ -3,14 +3,14 @@
     <!-- =============== serial ports =============== -->
 
     <register name="Serial Control and Status" short="sercs" address="0x34">
-        If \Fserialcount is 0, this register is not present.
+        If \FdmiSercsSerialcount is 0, this register is not present.
 
         <field name="serialcount" bits="31:28" access="R" reset="Preset">
             Number of supported serial ports.
         </field>
         <field name="0" bits="27" access="R" reset="0" />
         <field name="serial" bits="26:24" access="R/W" reset="0">
-            Select which serial port is accessed by \Rserrx and \Rsertx.
+            Select which serial port is accessed by \RdmiSerrx and \RdmiSertx.
         </field>
         <field name="error7" bits="23" access="R/W1C" reset="0"/>
         <field name="valid7" bits="22" access="R" reset="0" />
@@ -47,10 +47,10 @@
     </register>
 
     <register name="Serial TX Data" short="sertx" address="0x35">
-        If \Fserialcount is 0, this register is not present.
+        If \FdmiSercsSerialcount is 0, this register is not present.
 
         This register provides access to the write data queue of the serial port
-        selected by \Fserial in \Rsercs.
+        selected by \FdmiSercsSerial in \RdmiSercs.
 
         If the {\tt error} bit is not set and the queue is not full, a write to this register
         adds the written data to the core-to-debugger queue.
@@ -62,10 +62,10 @@
     </register>
 
     <register name="Serial RX Data" short="serrx" address="0x36">
-        If \Fserialcount is 0, this register is not present.
+        If \FdmiSercsSerialcount is 0, this register is not present.
 
         This register provides access to the read data queues of the serial port
-        selected by \Fserial in \Rsercs.
+        selected by \FdmiSercsSerial in \RdmiSercs.
 
         If the {\tt error} bit is not set and the queue is not empty, a read from this register reads the
         oldest entry in the debugger-to-core queue, and removes that entry from the queue.

--- a/xml/sw_registers.xml
+++ b/xml/sw_registers.xml
@@ -12,8 +12,8 @@
         Users can write this register to change the privilege level that
         the hart will run in when it resumes.
 
-        This register contains \Fprv from \Rdcsr, but in a place that the user
-        is expected to access. The user should not access \Rdcsr directly,
+        This register contains \FcsrDcsrPrv from \RcsrDcsr, but in a place that the user
+        is expected to access. The user should not access \RcsrDcsr directly,
         because doing so might interfere with the debugger.
 
         \begin{table}


### PR DESCRIPTION
This solves the problem we have with the same field existing in multiple
registers, as reported in #451.