### PR TITLE
ebreaks/ebreaku changes

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -23,17 +23,21 @@
             1: {\tt ebreak} instructions in M-mode enter Debug Mode.
         </field>
         <field name="0" bits="14" access="R" reset="0" />
-        <field name="ebreaks" bits="13" access="R/W" reset="0">
+        <field name="ebreaks" bits="13" access="WARL" reset="0">
             0: {\tt ebreak} instructions in S-mode behave as described in the
             Privileged Spec.
 
             1: {\tt ebreak} instructions in S-mode enter Debug Mode.
+
+            This bit is hardwired to 0 if the hart does not support S mode.
         </field>
-        <field name="ebreaku" bits="12" access="R/W" reset="0">
+        <field name="ebreaku" bits="12" access="WARL" reset="0">
             0: {\tt ebreak} instructions in U-mode behave as described in the
             Privileged Spec.
 
             1: {\tt ebreak} instructions in U-mode enter Debug Mode.
+
+            This bit is hardwired to 0 if the hart does not support U mode.
         </field>
         <field name="stepie" bits="11" access="WARL" reset="0">
             0: Interrupts are disabled during single stepping.


### PR DESCRIPTION
Fixed #453
Defined ebreaks and ebreaku as WARL fields that are 0 if the associated mode is not supported by the hart.