### PR TITLE
A few clarifications for triggers and abstract commands

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -263,13 +263,15 @@ Debuggers can only determine which abstract commands
 are supported by a given hart in a given state by attempting them
 and then looking at \FdmAbstractcsCmderr in \RdmAbstractcs to see if they were successful.
 Commands may be supported with some options set, but not with other options
-set. If a command has unsupported options set, the DM must set \FdmAbstractcsCmderr to 2
-(not supported).
+set. If a command is not supported or has unsupported options set,
+the DM must set \FdmAbstractcsCmderr to 2 (not supported).
+If a command and its options are supported but not in the
+current hart state, the DM must set \FdmAbstractcsCmderr to 4 (halt/resume).
 
 \begin{commentary}
-    Example: Every system must support the Access Register command, but may not
-    support accessing CSRs. If the debugger requests to read a CSR in that
-    case, the command will return ``not supported.''
+    Example: Every system must support the Access Register command, but may
+    choose not to support accessing CSRs. If the debugger requests to read
+    a CSR in that case, the command will return ``not supported.''
 \end{commentary}
 
 Debuggers execute abstract commands by writing them to \RdmCommand.  They
@@ -352,11 +354,11 @@ determines the kind of command. Table~\ref{tab:cmdtype} lists all commands.
         \hline
         \FdmCommandCmdtype & Command & Page \\
         \hline
-        0 & Access Register Command & \pageref{access register} \\
+        0 & Access Register Command & \pageref{acAccessregister} \\
         \hline
-        1 & Quick Access & \pageref{quick access} \\
+        1 & Quick Access & \pageref{acQuickaccess} \\
         \hline
-        2 & Access Memory Command & \pageref{access memory} \\
+        2 & Access Memory Command & \pageref{acAccessmemory} \\
         \hline
     \end{tabulary}
 \end{table}

--- a/overview.tex
+++ b/overview.tex
@@ -33,5 +33,5 @@ access block allows memory accesses without using a RISC-V hart to perform the
 access.
 
 Each RISC-V hart may implement a Trigger Module. When trigger conditions
-are met, harts will halt and inform the debug module that they have
-halted.
+are met, harts may either halt and inform the debug module that they have
+halted, or raise a machine mode breakpoint trap.

--- a/riscv-debug-draft.tex
+++ b/riscv-debug-draft.tex
@@ -1,0 +1,3 @@
+\newif\ifrelease
+\releasefalse
+\input{riscv-debug-spec.tex}

--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -3,7 +3,9 @@
     <register name="Access Register">
         \begin{steps}{This command gives the debugger access to CPU registers
         and allows it to execute the Program Buffer.
-        It performs the following sequence of operations:}
+        If the command and all requested options are supported in the current state
+	(see Section~\ref{abstractcommands}),
+        it performs the following sequence of operations:}
         \item If \FacAccessregisterWrite is clear and \FacAccessregisterTransfer is set, then copy data from
             the register specified by \FacAccessregisterRegno into the {\tt arg0} region of
             {\tt data}, and perform any side effects that occur when this
@@ -54,6 +56,9 @@
 
         This command modifies {\tt arg0} only when a register is read. The
         other {\tt data} registers are not changed.
+
+	For the Access Register Command, the \RdmCommand register (see Section~\ref{command})
+	is formatted as follows:
 
         <field name="cmdtype" bits="31:24">
             This is 0 to indicate Access Register Command.


### PR DESCRIPTION
From commit logs:

    In Section 3.7 Abstract Commands:
    Clarify cmderr=2 (not supported) if not supported at all,  vs.
    cmderr=4 (halt/resume) if supported but not in the current hart state.

    Then in subsections for each abstract command, clarify that their
    sequence of operation is conditional on their being supported as
    described above.  This makes it clear for example that cmderr=2 is
    checked before other error conditions.

    "may not" can mean "must not", reword to avoid ambiguity.

    Fix section references in cmdtype table.
_____
    Triggers can both halt and cause breakpoint exceptions.
_____
    Add missing file to generate the draft spec.