### PR TITLE
Change R/W1C to reduce requirements on hardware.

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -82,7 +82,9 @@ also listed in the index on page \pageref{index}.
         \hline
         R/W & Read/Write. \\
         \hline
-        R/W1C & Read/Write. For each bit in the field, writing 1 clears that bit. Writing 0 has no effect. \\
+        R/W1C & Read/Write Ones to Clear. Writing 0 to every bit has no effect.
+        Writing 1 to every bit clears the field. The result of other writes is
+        undefined. \\
         \hline
         WARZ & Write any, read zero. A debugger may write any value. When read
         this field returns 0. \\


### PR DESCRIPTION
This change might break debuggers that are written to support 0.13.
OpenOCD and Lauterbach have stated they're fine with that, and there
probably aren't that many other debuggers out there. The fix will be
trivial.