### PR TITLE
Forward progress and Debug Mode

### DIFF
--- a/core_debug.tex
+++ b/core_debug.tex
@@ -46,6 +46,11 @@ external debugging. How Debug Mode is implemented is not specified here.
 \item Effective XLEN is DXLEN.
 \end{steps}
 
+While in Debug Mode, the hart is waiting for commands from the external
+debugger.  Except when executing code from the optional Program Buffer,
+architectural forward progress guarantees are suspended while the hart
+is in Debug Mode.
+
 \begin{commentary}
     In general, the debugger is expected to be able to simulate all the effects of \FcsrMcontrolMprv.
     The exception is the case of Sv32 systems, which need \FcsrMcontrolMprv functionality in order to access


### PR DESCRIPTION
The ISA now requires forward progress [in section 1.2](https://github.com/riscv/riscv-isa-manual/commit/9a39b75241914a210d1f4f7a342d62743cd1dcb7#diff-c038c5db2b2517f740173da8a2636bc8R168).  Entering Debug Mode puts the forward progress at the mercy of the external debugger.  If it doesn't issue any commands or if it detaches completely then there's no forward progress (except that executing from the program buffer should still have a forward progress guarantee).

This lack of forward progress is allowable under the category of a "mechanism that explicitly waits for an event."  It's probably obvious to anyone in the debug world that halting inhibits forward progress but it's best to specify it.  https://github.com/riscv/riscv-isa-manual/issues/411 left this to the debug spec.
