### PR TITLE
Update implementations.tex

### DIFF
--- a/implementations.tex
+++ b/implementations.tex
@@ -29,7 +29,7 @@ modifications to a hart's datapath.
 When the halt request bit is set, the Debug Module raises a special interrupt
 to the selected harts. This interrupt causes each
 hart to enter Debug Mode and jump to a defined
-memory region that is serviced by the DM and is only accessible to the core in Debug Mode.
+memory region that is serviced by the DM and is only accessible to the hart in Debug Mode.
 When taking this exception, \Rpc is saved to \RcsrDpc and \FcsrDcsrCause is updated
 in \RcsrDcsr.
 

--- a/implementations.tex
+++ b/implementations.tex
@@ -29,7 +29,7 @@ modifications to a hart's datapath.
 When the halt request bit is set, the Debug Module raises a special interrupt
 to the selected harts. This interrupt causes each
 hart to enter Debug Mode and jump to a defined
-memory region that is serviced by the DM and is only accessible to the hart in Debug Mode.
+memory region that is serviced by the DM and is only accessible to the harts in Debug Mode.
 When taking this exception, \Rpc is saved to \RcsrDpc and \FcsrDcsrCause is updated
 in \RcsrDcsr.
 

--- a/implementations.tex
+++ b/implementations.tex
@@ -29,7 +29,7 @@ modifications to a hart's datapath.
 When the halt request bit is set, the Debug Module raises a special interrupt
 to the selected harts. This interrupt causes each
 hart to enter Debug Mode and jump to a defined
-memory region that is serviced by the DM.
+memory region that is serviced by the DM and is only accessible to the core in Debug Mode.
 When taking this exception, \Rpc is saved to \RcsrDpc and \FcsrDcsrCause is updated
 in \RcsrDcsr.
 


### PR DESCRIPTION
In the suggested implementation which uses memory map, clarify that the region should only be accessible in Debug Mode.

If this region is accessible in non-debug Mode, it is unclear how the Debug MOdule is supposed to interpret the interactions with the memory regions specified here.