### PR TITLE
Git ignore intermediate and output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# LaTeX intermediate files
+*.aux
+*.idx
+*.ilg
+*.ind
+*.lof
+*.log
+*.out
+*.toc
+*.lot
+*.hst
+*.ver
+
+# Generated files
+*_registers.tex
+*_registers.tex.inc
+*_registers.h
+serial.*
+abstract_commands.*
+debug_defines.h
+
+# Changelogs
+changelog.tex
+vc.tex
+
+# Resulting PDFs
+riscv-debug-workgroup-notes.pdf


### PR DESCRIPTION
Add a gitignore file to keep the output of `git status` a bit cleaner. There's still the checked-in PDF that differs all the time, but that needs to be solved by CI or another way which doesn't include checking in this file.