### PR TITLE
Tiny style fix for email "link" on title page

### DIFF
--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -74,7 +74,7 @@ Version \versionnum\\
 \GITHash
 }
 \author{Editors: \\
-Ernie Edgar \textless ernie.edgar@sifive.com \textgreater, SiFive, Inc. \\
+Ernie Edgar \textless ernie.edgar@sifive.com\textgreater, SiFive, Inc. \\
 Tim Newsome \textless tim@sifive.com\textgreater, SiFive, Inc.}
 \date{\GITAuthorDate}
 \maketitle


### PR DESCRIPTION
Email addresses are typically given like "<email@example.com>" with no
spaces. That was the case for Tim's email address, but not for the other
one. Fix that for consistency (it's the title page after all!)