### PR TITLE
Fix page references in cmdtype table

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -355,11 +355,11 @@ determines the kind of command. Table~\ref{tab:cmdtype} lists all commands.
         \hline
         \FdmCommandCmdtype & Command & Page \\
         \hline
-        0 & Access Register Command & \pageref{access register} \\
+        0 & Access Register Command & \pageref{acAccessregister} \\
         \hline
-        1 & Quick Access & \pageref{quick access} \\
+        1 & Quick Access & \pageref{acQuickaccess} \\
         \hline
-        2 & Access Memory Command & \pageref{access memory} \\
+        2 & Access Memory Command & \pageref{acAccessmemory} \\
         \hline
     \end{tabulary}
 \end{table}


### PR DESCRIPTION
These were showing up as ??? in the output document.