### PR TITLE
dmcontrol.hartreset is WARL, not R/W

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -159,7 +159,7 @@
 
             Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
-        <field name="hartreset" bits="29" access="R/W" reset="0">
+        <field name="hartreset" bits="29" access="WARL" reset="0">
             This optional field writes the reset bit for all the currently
             selected harts.  To perform a reset the debugger writes 1, and then
             writes 0 to deassert the reset signal.


### PR DESCRIPTION
The spec says about the dmcontrol.hartreset field:
 "If this feature is not implemented, the bit always
stays 0, so after writing 1 the debugger can read
the register back to see if the feature is supported."

That makes it a WARL field not a R/W field. Changing the annotation to
make it more obvious to the reader.