### PR TITLE
dcsr.prv should be WARL, not R/W

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -117,7 +117,7 @@
             The debugger must not change the value of this bit while the hart
             is running.
         </field>
-        <field name="prv" bits="1:0" access="R/W" reset="3">
+        <field name="prv" bits="1:0" access="WARL" reset="3">
             Contains the privilege level the hart was operating in when Debug
             Mode was entered. The encoding is described in Table
             \ref{tab:privlevel}.  A debugger can change this value to change


### PR DESCRIPTION
If a privilege mode is not supported by the core, or if a privilege
change is not allowed, the dcsr.prv register is set to a supported
value. This makes this register WARL, not R/W, as indicated in the
table.