### PR TITLE
Time may pass before dmactive becomes high.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -548,6 +548,7 @@ while writes should be ignored, with the following mandatory exceptions:
     \item Write \RdmDmcontrol, preserving \FdmDmcontrolHartreset, \FdmDmcontrolHasel, \FdmDmcontrolHartsello, and
         \FdmDmcontrolHartselhi from the value that was read, setting \FdmDmcontrolDmactive, and
         clearing all the other bits.
+    \item Read \RdmDmcontrol until \FdmDmcontrolDmactive is high.
     \item Read \RdmDmstatus, which contains \FdmDmstatusVersion.
 \end{steps}
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -242,9 +242,9 @@
             correct data.
 
             1: The module functions normally. After writing 1, the debugger should
-            read \RdmDmcontrol to confirm that this bit is now high. Hardware may
-            take a long time to set this bit if it's not currently ready for
-            debugging to take place.
+            poll \RdmDmcontrol until \FdmDmcontrolDmactive is high. Hardware may
+            take an arbitrarily long time to initialize and will indicate completion
+            by setting dmactive to 1.
 
             No other mechanism should exist that may result in resetting the
             Debug Module after power up.

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -241,7 +241,10 @@
             to the module may fail. Specifically, \FdmDmstatusVersion may not return
             correct data.
 
-            1: The module functions normally.
+            1: The module functions normally. After writing 1, the debugger should
+            read \RdmDmcontrol to confirm that this bit is now high. Hardware may
+            take a long time to set this bit if it's not currently ready for
+            debugging to take place.
 
             No other mechanism should exist that may result in resetting the
             Debug Module after power up.


### PR DESCRIPTION
This addresses a concern of how the debugger can know when hardware is
ready to be debugged, discussed on the mailing list. subject:"Email
discussion: how can a debugger know when a target is ready for it?"