### PR TITLE
Make the emitted registers chisel3

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -255,7 +255,7 @@ def write_cheader( fd, registers ):
 
 def write_chisel( fd, registers ):
     fd.write("package freechips.rocketchip.devices.debug\n\n")
-    fd.write("import Chisel._\n\n")
+    fd.write("import chisel3._\n\n")
 
     fd.write("// This file was auto-generated from the repository at https://github.com/riscv/riscv-debug-spec.git,\n")
     fd.write("// 'make chisel'\n\n")


### PR DESCRIPTION
Previously they were emitted in `Chisel._` (compatability mode). As part of upgrading to `chisel3`, export them as `chisel3` (note this doesn't actually need to change anything) else in the emitted code.