### PR TITLE
Make haltsum0 optional if there is only one hart.

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -615,6 +615,8 @@
         is halted or not. Unavailable/nonexistent harts are not considered to
         be halted.
 
+        This register may not be present in systems with fewer than 2 harts.
+
         The LSB reflects the halt status of hart \{hartsel[19:5],5'h0\}, and the
         MSB reflects halt status of hart \{hartsel[19:5],5'h1f\}.
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -615,7 +615,8 @@
         is halted or not. Unavailable/nonexistent harts are not considered to
         be halted.
 
-        This register may not be present in systems with fewer than 2 harts.
+        This register might not be present if fewer than 2 harts are connected
+        to this DM.
 
         The LSB reflects the halt status of hart \{hartsel[19:5],5'h0\}, and the
         MSB reflects halt status of hart \{hartsel[19:5],5'h1f\}.
@@ -628,8 +629,8 @@
         harts is halted or not. Unavailable/nonexistent harts are not considered to
         be halted.
 
-        This register may not be present in systems with fewer than
-        33 harts.
+        This register might not be present if fewer than 33 harts are connected
+        to this DM.
 
         The LSB reflects the halt status of harts \{hartsel[19:10],10'h0\}
         through \{hartsel[19:10],10'h1f\}.
@@ -644,8 +645,8 @@
         harts is halted or not. Unavailable/nonexistent harts are not considered to
         be halted.
 
-        This register may not be present in systems with fewer than
-        1025 harts.
+        This register might not be present if fewer than 1025 harts are connected
+        to this DM.
 
         The LSB reflects the halt status of harts \{hartsel[19:15],15'h0\}
         through \{hartsel[19:15],15'h3ff\}.
@@ -660,8 +661,8 @@
         harts is halted or not. Unavailable/nonexistent harts are not considered to
         be halted.
 
-        This register may not be present in systems with fewer than
-        32769 harts.
+        This register might not be present if fewer than 32769 harts are connected
+        to this DM.
 
         The LSB reflects the halt status of harts 20'h0 through 20'h7fff.
         The MSB reflects the halt status of harts 20'hf8000 through 20'hfffff.


### PR DESCRIPTION
This is not forwards compatible. Debuggers that rely on haltsum0 would
break with this change. But it makes the debug interface on tiny 1-hart
systems smaller, especially because it allows the number of address bits
in the DMI to be 1 less. (Haltsum0 at 0x40 due to other efforts to
maintain backwards compatibility.)

Fixes #389.