### PR TITLE
Fix conflict in sbdata0/sbautoincrement definition.

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -868,10 +868,11 @@
         \begin{steps}{Reads from this register start the following:}
             \item ``Return'' the data.
             \item Set \FdmSbcsSbbusy.
-            \item If \FdmSbcsSbreadondata is set, perform a system bus read from the
-            address contained in {\tt sbaddress}, placing the result in {\tt
-            sbdata}.
-            \item If \FdmSbcsSbautoincrement is set, increment {\tt sbaddress}.
+            \item \begin{steps}{If \FdmSbcsSbreadondata is set:}
+                \item Perform a system bus read from the address contained in
+                        {\tt sbaddress}, placing the result in {\tt sbdata}.
+                \item If \FdmSbcsSbautoincrement is set, increment {\tt sbaddress}.
+            \end{steps}
             \item Clear \FdmSbcsSbbusy.
         \end{steps}
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -871,7 +871,8 @@
             \item \begin{steps}{If \FdmSbcsSbreadondata is set:}
                 \item Perform a system bus read from the address contained in
                         {\tt sbaddress}, placing the result in {\tt sbdata}.
-                \item If \FdmSbcsSbautoincrement is set, increment {\tt sbaddress}.
+                \item If \FdmSbcsSbautoincrement is set and the read was
+                        successful, increment {\tt sbaddress}.
             \end{steps}
             \item Clear \FdmSbcsSbbusy.
         \end{steps}


### PR DESCRIPTION
Autoincrement only happens if an access actually takes place.

On the list, see subject:"sbaccess ambiguity".