### PR TITLE
Adding version encoding for 0.14 spec.

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -100,8 +100,8 @@
             2: There is a Debug Module and it conforms to version 0.13 of this
             specification.
 
-	    3: There is a Debug Module and it conforms to version 0.14 of this
-	    specification.
+            3: There is a Debug Module and it conforms to version 0.14 of this
+            specification.
 
             15: There is a Debug Module but it does not conform to any
             available version of this spec.

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -91,7 +91,7 @@
             1: \RdmConfstrptrZero--\RdmConfstrptrThree hold the address of the
             configuration string.
         </field>
-        <field name="version" bits="3:0" reset="2" access="R">
+        <field name="version" bits="3:0" reset="3" access="R">
             0: There is no Debug Module present.
 
             1: There is a Debug Module and it conforms to version 0.11 of this
@@ -99,6 +99,9 @@
 
             2: There is a Debug Module and it conforms to version 0.13 of this
             specification.
+
+	    3: There is a Debug Module and it conforms to version 0.14 of this
+	    specification.
 
             15: There is a Debug Module but it does not conform to any
             available version of this spec.


### PR DESCRIPTION
I'm of the view that there are sufficient changes in 0.14 to warrant a distinct encoding for the version. This pull request simply adds that encoding to the spec.