### PR TITLE
Debuggers should know when harts are unavailable.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -175,10 +175,10 @@ continuous hart index space. In order to let the debugger discover all harts,
 they must show up as unavailable even if there is no chance of them ever
 becoming available.
 
-While a hart is unavailable, {\tt unavail} is set for that hart. The bit
-remains set once the hart is available again, until the debugger acknowledges
-it using \FdmDmcontrolAckunavail. There are no guarantees about the state of
-the hart when it comes back.
+While a hart is unavailable, {\tt unavail} is set for that hart. If
+\FdmDmstatusStickyunavail is set, then the bit remains set once the hart is
+available again, until the debugger acknowledges it using
+\FdmDmcontrolAckunavail. There are no guarantees about the state of the hart when it comes back.
 
 Harts are running when they are executing normally, as if no debugger was
 attached. This includes being in a low power mode or waiting for an interrupt,

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -175,6 +175,11 @@ continuous hart index space. In order to let the debugger discover all harts,
 they must show up as unavailable even if there is no chance of them ever
 becoming available.
 
+While a hart is unavailable, {\tt unavail} is set for that hart. The bit
+remains set once the hart is available again, until the debugger acknowledges
+it using \FdmDmcontrolAckunavail. There are no guarantees about the state of
+the hart when it comes back.
+
 Harts are running when they are executing normally, as if no debugger was
 attached. This includes being in a low power mode or waiting for an interrupt,
 as long as a halt request will result in the hart being halted.

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -168,17 +168,17 @@ with indexes higher than the first nonexistent one.
 Harts are unavailable if they might exist/become available at a later time, or
 if there are other harts with higher indexes than this one. Harts may be
 unavailable for a variety of reasons including being reset, temporarily powered
-down, and not being plugged into the system.
+down, and not being plugged into the system. That means harts might become
+available or unavailable at any time, although these events should be rare
+in systems built to be easily debugged.
+There are no guarantees about the state of the hart when it becomes available.
+
 Systems with very large number of harts may
 permanently disable some during manufacturing, leaving holes in the otherwise
 continuous hart index space. In order to let the debugger discover all harts,
 they must show up as unavailable even if there is no chance of them ever
 becoming available.
 
-While a hart is unavailable, {\tt unavail} is set for that hart. If
-\FdmDmstatusStickyunavail is set, then the bit remains set once the hart is
-available again, until the debugger acknowledges it using
-\FdmDmcontrolAckunavail. There are no guarantees about the state of the hart when it comes back.
 
 Harts are running when they are executing normally, as if no debugger was
 attached. This includes being in a low power mode or waiting for an interrupt,

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -7,7 +7,13 @@
         the currently selected harts, as defined in \FdmDmcontrolHasel.  Its address will
         not change in the future, because it contains \FdmDmstatusVersion.
 
-        <field name="0" bits="31:23" access="R" reset="0" />
+        <field name="0" bits="31:24" access="R" reset="0" />
+        <field name="stickyunavail" bits="23" access="R" reset="Preset">
+            0: The per-hart {\tt unavail} bits reflect the current state of the hart.
+
+            1: The per-hart {\tt unavail} bits are sticky. Once they are set, they will
+            not clear until the debugger acknowledges them using \FdmDmcontrolAckunavail.
+        </field>
         <field name="impebreak" bits="22" access="R" reset="Preset">
             If 1, then there is an implicit {\tt ebreak} instruction at the
             non-existent word immediately after the Program Buffer. This saves

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -42,10 +42,12 @@
             this platform.
         </field>
         <field name="allunavail" bits="13" access="R" reset="-">
-            This field is 1 when all currently selected harts are unavailable.
+            This field is 1 when all currently selected harts are unavailable,
+            or were unavailable without that being acknowledged.
         </field>
         <field name="anyunavail" bits="12" access="R" reset="-">
-            This field is 1 when any currently selected hart is unavailable.
+            This field is 1 when any currently selected hart is unavailable,
+            or was unavailable without that being acknowledged.
         </field>
         <field name="allrunning" bits="11" access="R" reset="-">
             This field is 1 when all currently selected harts are running.
@@ -183,7 +185,13 @@
 
             Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
-        <field name="0" bits="27" access="R" reset="0" />
+        <field name="ackunavail" bits="27" access="W1" reset="-">
+            0: No effect.
+
+            1: Clears {\tt unavail} for any selected harts.
+
+            Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
+        </field>
         <field name="hasel" bits="26" access="R/W" reset="0">
             Selects the definition of currently selected harts.
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -48,12 +48,14 @@
             this platform.
         </field>
         <field name="allunavail" bits="13" access="R" reset="-">
-            This field is 1 when all currently selected harts are unavailable,
-            or were unavailable without that being acknowledged.
+            This field is 1 when all currently selected harts are
+            unavailable, or (if \FdmDmstatusStickyunavail is 1) were
+            unavailable without that being acknowledged.
         </field>
         <field name="anyunavail" bits="12" access="R" reset="-">
             This field is 1 when any currently selected hart is unavailable,
-            or was unavailable without that being acknowledged.
+            or (if \FdmDmstatusStickyunavail is 1) was unavailable without
+            that being acknowledged.
         </field>
         <field name="allrunning" bits="11" access="R" reset="-">
             This field is 1 when all currently selected harts are running.


### PR DESCRIPTION
Make unavail sticky, needing to be acknowledged with new ackunavail bit.

This is a backwards incompatible change. I think it's OK because
implementations that support unavailable harts are rare (I don't know of
any), and the change only means that debuggers must be updated. If
hardware doesn't implement this then everything will still work,
although users might not be notified when harts become unavailable.

Fixes #461.