### PR TITLE
aamvirtual: Clarification for systems without address translations

### DIFF
--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -191,6 +191,10 @@
 
             1: Addresses are virtual, and translated the way they would be from
             M-mode, with \FcsrMcontrolMprv set.
+
+            Debug Modules on systems without address translation (i.e. virtual addresses equal physical)
+            may optionally allow \FacAccessmemoryAamvirtual set to 1, which would produce the same result as
+            that same abstract command with \FacAccessmemoryAamvirtual cleared.
         </field>
         <field name="aamsize" bits="22:20">
             0: Access the lowest 8 bits of the memory location.


### PR DESCRIPTION
Adding brief clarification of permitted "aamvirtual" bit behavior on systems without address translation, per the following discussion: https://lists.riscv.org/g/tech-debug/topic/72759746