### PR TITLE
Add dret to rule 8.

### DIFF
--- a/core_debug.tex
+++ b/core_debug.tex
@@ -32,9 +32,9 @@ How Debug Mode is implemented is not specified here.
 \item If \FcsrDcsrStoptime is 0 then timers continue. If it is 1 then
     timers are stopped.
 \item The {\tt wfi} instruction acts as a {\tt nop}.
-\item Almost all instructions that change the privilege level have undefined
-    behavior.  This includes {\tt ecall}, {\tt mret}, {\tt sret},
-    and {\tt uret}.  (To change the privilege level, the debugger can write
+\item Almost all instructions that change the privilege level have \unspecified\ 
+    behavior.  This includes {\tt ecall}, {\tt mret}, {\tt sret}, {\tt uret},
+    and {\tt dret}.  (To change the privilege level, the debugger can write
     \FcsrDcsrPrv in \RcsrDcsr). The only exception is {\tt ebreak}, which ends
     execution of the Program Buffer when executed.
 \item \label{fence} Completing Program Buffer execution is considered output for the purpose
@@ -148,14 +148,12 @@ executed.
 
 \section{{\tt dret} Instruction} \label{dret}
 
-To return from Debug Mode, a new instruction is defined: {\tt dret}. It has an
-encoding of 0x7b200073. On harts which support this instruction,
-executing {\tt dret} in Debug Mode cause the hart to resume as described above.
+To assist with certain types of implementations (see \ref{execution_based}),
+a new instruction is defined: {\tt dret}. It has an encoding of 0x7b200073.
 
+Execution of this instruction in the program buffer causes \unspecified\ behavior.
 Executing {\tt dret} outside of Debug Mode causes an illegal instruction exception.
 
-It is not necessary for the debugger to know whether an implementation supports
-{\tt dret}, as the Debug Module will ensure that it is executed if necessary.
 It is defined in this specification only to reserve the opcode and
 allow for reusable Debug Module implementations.
 

--- a/implementations.tex
+++ b/implementations.tex
@@ -17,7 +17,7 @@ Bus Access.
 This implementation could allow a debugger to collect information from the hart
 even when that hart is unable to execute instructions.
 
-\section{Execution Based}
+\section{Execution Based} \label{execution_based}
 
 This implementation only implements the Access Register abstract command
 for GPRs on a halted hart, and relies on the Program Buffer for all other

--- a/preamble.tex
+++ b/preamble.tex
@@ -144,5 +144,4 @@
 \newcommand{\wlrl}{\textbf{WLRL}}
 \newcommand{\warl}{\textbf{WARL}}
 
-
-
+\newcommand{\unspecified}{\textsc{unspecified}}


### PR DESCRIPTION
Changed the dret section in the normative architecture section to only include architectural requirements and refer to the appendix for implementation details.
Added UNSPECIFIED to the preamble to conform to the overall architecture.
