### PR TITLE
Clarify that PMP must allow access to DM for debug to be possible

### DIFF
--- a/implementations.tex
+++ b/implementations.tex
@@ -72,8 +72,8 @@ For additional flexibility, \RdmProgbufZero, etc. are mapped into regular memory
 immediately preceding \RdmDataZero, in order to form a contiguous region of memory which
 can be used for either program execution or data transfer.
 
-Note that for debug to be possible, the PMP must allow M-mode fetches, loads, and stores
-to the address range associated with the Debug Module.
+Note that for debug to be possible, the PMP must not disallow fetches, loads, or stores
+in the address range associated with the Debug Module when the hart in Debug Mode.
 
 \section{Debug Module Interface Signals} \label{dmi_signals}
 

--- a/implementations.tex
+++ b/implementations.tex
@@ -72,6 +72,9 @@ For additional flexibility, \RdmProgbufZero, etc. are mapped into regular memory
 immediately preceding \RdmDataZero, in order to form a contiguous region of memory which
 can be used for either program execution or data transfer.
 
+Note that for debug to be possible, the PMP must allow M-mode fetches, loads, and stores
+to the address range associated with the Debug Module.
+
 \section{Debug Module Interface Signals} \label{dmi_signals}
 
 As stated in section \ref{dmi} the details of the DMI are left to the system designer.

--- a/implementations.tex
+++ b/implementations.tex
@@ -73,7 +73,7 @@ immediately preceding \RdmDataZero, in order to form a contiguous region of memo
 can be used for either program execution or data transfer.
 
 Note that for debug to be possible, the PMP must not disallow fetches, loads, or stores
-in the address range associated with the Debug Module when the hart in Debug Mode.
+in the address range associated with the Debug Module when the hart is in Debug Mode.
 
 \section{Debug Module Interface Signals} \label{dmi_signals}
 


### PR DESCRIPTION
A question came up about the relationship between PMP and debug in an Execution-Based design.  This PR adds a clarifying statement to the non-normative appendix section describing Execution-Based implementations saying that for debug to be possible, the PMP must allow access to the debug module address range when in debug mode.