### PR TITLE
Use official RISC-V terminology

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -435,13 +435,14 @@ Mode, and \FdmAbstractcsCmderr is set to 3 ({\tt exception error}).  If the debu
 executes a program that doesn't terminate with an {\tt ebreak} instruction, the
 hart will remain in Debug Mode and the debugger will lose control of the hart.
 
-Executing the Program Buffer may clobber \RcsrDpc. If that is the case, it must be
+Executing the Program Buffer may cause the value of \RcsrDpc to become \unspecified. If that is the case, it must be
 possible to read/write \RcsrDpc using an abstract command with \FacAccessregisterPostexec not set.
 The debugger must attempt to save \RcsrDpc between halting and
 executing a Program Buffer, and then restore \RcsrDpc before leaving Debug Mode.
 
 \begin{commentary}
-    Allowing Program Buffer execution to clobber \RcsrDpc allows for direct
+    Allowing \RcsrDpc to become \unspecified\ upon Program Buffer execution
+    allows for direct
     implementations that don't have a separate PC register, and do need to use
     the PC when executing the Program Buffer.
 \end{commentary}


### PR DESCRIPTION
I had a conversation today with someone who was confused by "clobber" so I propose to use the official term.
