### PR TITLE
List all DM registers in Table 3.8.

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -334,21 +334,28 @@ def compare_address(a, b):
 
 def print_latex_index( registers ):
     print(registers.description)
+
+    columns = [
+        ("Address", "r"),
+        ("Name", "l")]
+    if any(r.sdesc for r in registers.registers):
+        columns.append(("Description", "l"))
+    columns.append(("Page", "l"))
+
     # Force this table HERE so that it doesn't get moved into the next section,
     # which will be the description of a register.
-    print("\\begin{table}[H]")
-    print("   \\begin{center}")
-    print("      \\caption{%s}" % registers.name)
-    print("      \\label{%s}" % toLatexIdentifier(registers.prefix, registers.label))
-    if any( r.sdesc for r in registers.registers ):
-        print("      \\begin{tabular}{|r|l|l|l|}")
-        print("      \\hline")
-        print("      Address & Name & Description & Page \\\\")
-    else:
-        print("      \\begin{tabular}{|r|l|l|}")
-        print("      \\hline")
-        print("      Address & Name & Page \\\\")
+    print("   \\begin{longtable}{|%s|}" % "|".join(b for a, b in columns))
+    print("      \\caption{%s \\label{%s}}\\\\" %
+            (registers.name, toLatexIdentifier(registers.prefix, registers.label)))
     print("      \\hline")
+    print("      %s \\\\" % (" & ".join(a for a, b in columns)))
+    print("      \\hline")
+    print("      \\endhead")
+
+    print("      \\multicolumn{%d}{r}{\\textit{Continued on next page}} \\\\" %
+            len(columns))
+    print("      \\endfoot")
+    print("      \\endlastfoot")
     for r in sorted( registers.registers,
             key=cmp_to_key(lambda a, b: compare_address(a.address, b.address))):
         if r.short and (r.fields or r.description):
@@ -364,9 +371,7 @@ def print_latex_index( registers ):
         else:
             print("%s & %s & %s \\\\" % ( r.address, name, page ))
     print("         \hline")
-    print("      \end{tabular}")
-    print("   \end{center}")
-    print("\end{table}")
+    print("   \end{longtable}")
 
 def print_latex_custom( registers ):
     sub = "sub" * registers.depth
@@ -459,7 +464,6 @@ def print_latex_custom( registers ):
         if any( f.description for f in r.fields ):
             print("\\tabletail{\\hline \\multicolumn{%d}{|r|}" % len(columns))
             print("   {{Continued on next page}} \\\\ \\hline}")
-            print("\\begin{center}")
             print("   \\begin{longtable}{|%s|}" % "|".join(c[0] for c in columns))
 
             print("   \\hline")
@@ -480,9 +484,7 @@ def print_latex_custom( registers ):
                     print("%s\\\\" % " & ".join(str(getattr(f, c[2])) for c in columns[1:]))
                     print("   \\hline")
 
-            #print "   \\end{tabulary}"
             print("   \\end{longtable}")
-            print("\\end{center}")
         print()
 
 def print_latex_register( registers ):

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -962,9 +962,9 @@
     </register>
 
     <register name="Custom Features 0" short="custom0" address="0x70">
-        The optional {\tt custom} registers may be used for non-standard
-        features. Future version of the debug spec will not use these
-        addresses.
+        The optional \RdmCustomZero through \RdmCustomFifteen registers may
+        be used for non-standard features. Future versions of the debug spec
+        will not use these addresses.
     </register>
     <register name="Custom Features 1" short="custom1" address="0x71" />
     <register name="Custom Features 2" short="custom2" address="0x72" />

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -539,7 +539,6 @@
 
         <field name="data" bits="31:0" access="R/W" reset="0" />
     </register>
-    <!--
     <register name="Abstract Data 1" short="data1" address="0x05" />
     <register name="Abstract Data 2" short="data2" address="0x06" />
     <register name="Abstract Data 3" short="data3" address="0x07" />
@@ -550,7 +549,6 @@
     <register name="Abstract Data 8" short="data8" address="0x0c" />
     <register name="Abstract Data 9" short="data9" address="0x0d" />
     <register name="Abstract Data 10" short="data10" address="0x0e" />
-    -->
     <register name="Abstract Data 11" short="data11" address="0x0f" />
 
     <!-- =============== Program Buffer =============== -->
@@ -567,7 +565,6 @@
 
         <field name="data" bits="31:0" access="R/W" reset="0" />
     </register>
-    <!--
     <register name="Program Buffer 1" short="progbuf1" address="0x21" />
     <register name="Program Buffer 2" short="progbuf2" address="0x22" />
     <register name="Program Buffer 3" short="progbuf3" address="0x23" />
@@ -582,7 +579,6 @@
     <register name="Program Buffer 12" short="progbuf12" address="0x2c" />
     <register name="Program Buffer 13" short="progbuf13" address="0x2d" />
     <register name="Program Buffer 14" short="progbuf14" address="0x2e" />
-    -->
     <register name="Program Buffer 15" short="progbuf15" address="0x2f" />
  
     <!-- =============== authentication =============== -->
@@ -966,13 +962,24 @@
     </register>
 
     <register name="Custom Features 0" short="custom0" address="0x70">
-        This optional register may be used for non-standard features. Future
-        version of the debug spec will not use this address.
+        The optional {\tt custom} registers may be used for non-standard
+        features. Future version of the debug spec will not use these
+        addresses.
     </register>
-
-    <register name="Custom Features 15" short="custom15" address="0x7f">
-        This optional register may be used for non-standard features. Future
-        version of the debug spec will not use this address.
-    </register>
+    <register name="Custom Features 1" short="custom1" address="0x71" />
+    <register name="Custom Features 2" short="custom2" address="0x72" />
+    <register name="Custom Features 3" short="custom3" address="0x73" />
+    <register name="Custom Features 4" short="custom4" address="0x74" />
+    <register name="Custom Features 5" short="custom5" address="0x75" />
+    <register name="Custom Features 6" short="custom6" address="0x76" />
+    <register name="Custom Features 7" short="custom7" address="0x77" />
+    <register name="Custom Features 8" short="custom8" address="0x78" />
+    <register name="Custom Features 9" short="custom9" address="0x79" />
+    <register name="Custom Features 10" short="custom10" address="0x7a" />
+    <register name="Custom Features 11" short="custom11" address="0x7b" />
+    <register name="Custom Features 12" short="custom12" address="0x7c" />
+    <register name="Custom Features 13" short="custom13" address="0x7d" />
+    <register name="Custom Features 14" short="custom14" address="0x7e" />
+    <register name="Custom Features 15" short="custom15" address="0x7f" />
 
 </registers>


### PR DESCRIPTION
But don't give them each a description if it's redundant.

The main change here is that registers.py now generates an "index" table
that can be split across pages.

This change supersedes #560.