### PR TITLE
Create LaTeX macros for fields without descriptions.

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -205,7 +205,7 @@ def write_definitions( fd, registers ):
             fd.write( "\\defregname{\\R%s}{\\hyperref[%s]{%s}}\n" % (
                 macroName, toLatexIdentifier( registers.prefix, r.label ), r.short or r.label ) )
         for f in r.fields:
-            if f.description and f.define:
+            if f.define:
                 fd.write( "\\deffieldname{\\F%s}{\\hyperref[%s]{%s}}\n" % (
                         toLatexIdentifier( registers.prefix, regid, f.name ),
                         toLatexIdentifier( registers.prefix, regid, f.name ),


### PR DESCRIPTION
We used to not do this because those fields would often have the same
name as some other field, and there was a name collision. Now however we
have long, fully qualified names. This change is needed for #588 which
references \FcsrTextraSixtyfourSselect.