### PR TITLE
add dmstatus.ndmresetpending to allow a debugger to determine when ndmreset is complete

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -84,15 +84,6 @@ immediately enter Debug Mode (halted state).
 Otherwise, if the hart was initially running it will execute normally (running state)
 and if the hart was initially halted it should now be running but may be halted.
 
-To determine when a requested \FdmDmcontrolNdmreset system reset has
-completed, the debugger can poll \FdmDmstatusNdmresetpending,
-if implemented.  To allow for detection of this optional feature,
-\FdmDmstatusNdmresetpending, if implemented, returns one on reads whenever
-\FdmDmcontrolNdmreset is one.  If implemented, it remains one after deassertion of
-\FdmDmcontrolNdmreset until the requested system reset is complete,
-after which it is cleared by the Debug Module.  If this feature is not implemented, 
-\FdmDmstatusNdmresetpending always returns zero.
-
 \begin{commentary}
     There is no general, reliable way for the debugger to know when reset has
     actually begun.

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -84,6 +84,15 @@ immediately enter Debug Mode (halted state).
 Otherwise, if the hart was initially running it will execute normally (running state)
 and if the hart was initially halted it should now be running but may be halted.
 
+To determine when a requested \FdmDmcontrolNdmreset system has
+completed, the debugger can poll the \FdmDmstatusNdmresetpending bit,
+if implemented.  To allow for detection of this optional feature,
+\FdmDmstatusNdmresetpending, if implemented, returns one on reads whenever
+\FdmDmcontrolNdmreset is one.  If implemented, it remains one after deassertion of
+\FdmDmcontrolNdmreset until the requested system reset is complete,
+after which it is cleared by the Debug Module.  If this feature is not implemented, 
+\FdmDmstatusNdmresetpending always returns zero.
+
 \begin{commentary}
     There is no general, reliable way for the debugger to know when reset has
     actually begun.

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -85,7 +85,7 @@ Otherwise, if the hart was initially running it will execute normally (running s
 and if the hart was initially halted it should now be running but may be halted.
 
 To determine when a requested \FdmDmcontrolNdmreset system reset has
-completed, the debugger can poll the \FdmDmstatusNdmresetpending bit,
+completed, the debugger can poll \FdmDmstatusNdmresetpending,
 if implemented.  To allow for detection of this optional feature,
 \FdmDmstatusNdmresetpending, if implemented, returns one on reads whenever
 \FdmDmcontrolNdmreset is one.  If implemented, it remains one after deassertion of

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -84,7 +84,7 @@ immediately enter Debug Mode (halted state).
 Otherwise, if the hart was initially running it will execute normally (running state)
 and if the hart was initially halted it should now be running but may be halted.
 
-To determine when a requested \FdmDmcontrolNdmreset system has
+To determine when a requested \FdmDmcontrolNdmreset system reset has
 completed, the debugger can poll the \FdmDmstatusNdmresetpending bit,
 if implemented.  To allow for detection of this optional feature,
 \FdmDmstatusNdmresetpending, if implemented, returns one on reads whenever

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -8,7 +8,7 @@
         not change in the future, because it contains \FdmDmstatusVersion.
 
         <field name="0" bits="31:25" access="R" reset="0" />
-        <field name="ndmresetpending" bits="24" access="R" reset="Preset">
+        <field name="ndmresetpending" bits="24" access="R" reset="-">
             0: Unimplemented, or \FdmDmcontrolNdmreset is zero and no ndmreset is currently 
             in progress.
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -7,7 +7,13 @@
         the currently selected harts, as defined in \FdmDmcontrolHasel.  Its address will
         not change in the future, because it contains \FdmDmstatusVersion.
 
-        <field name="0" bits="31:24" access="R" reset="0" />
+        <field name="0" bits="31:25" access="R" reset="0" />
+        <field name="ndmresetpending" bits="24" access="R" reset="Preset">
+            0: Unimplemented, or \FdmDmcontrolNdmreset is zero and no ndmreset is currently 
+            in progress.
+
+            1: \FdmDmcontrolNdmreset is currently nonzero, or there is an ndmreset in progress.
+        </field>
         <field name="stickyunavail" bits="23" access="R" reset="Preset">
             0: The per-hart {\tt unavail} bits reflect the current state of the hart.
 


### PR DESCRIPTION
Currently there is a well-defined way for a debugger to determine when reset has begun and completed for any arbitrary subset of harts (most recently discussed in PR 480, 494).  However the system as a whole is composed of more than just the harts, and there is no overarching “havendmreset” signal analogous to the per-hart “havereset” signals to indicate when this state outside of the harts has completed reset.  

Because some system state accessible to a debugger (for example, peripherals' register space via SBA) can continue to be in reset after all harts in a system have completed reset,  it is useful for the debugger to know when ndmreset is still happening and when it has completed.

This PR implements a way for a debugger to determine if ndmreset has completed on implementations that choose to support the feature.  It proposes to use a bit of dmstatus called ndmresetpending that can be asserted by a debug module at the start of ndmreset and deasserted when ndmreset is complete.  Hardware that does not implement this feature leaves the bit hardwired zero (as prior to this PR), and a debugger is not required to read the bit, in order to maintain backward compatibility.

The proposal also has the ndmresetpending bit return a value of 1 on reads whenever ndmreset is 1.  This part of the proposal is in place to allow a debugger to detect whether the feature is supported without requiring a separate 'capabilities' bit or breaking backward compatibility.  Therefore, the prescription for using this feature is: when requesting ndmreset,

1. write(ndmreset, 1)
2. if(debugger_wants_to_poll) debugger_will_poll = read(ndmresetpending); else debugger_will_poll = 0;
3. write(ndmreset, 0)
4. if (debugger_will_poll) while (read(ndmresetpending)) { wait }

so debuggers not wanting to use this feature have no change to present behavior.
