### PR TITLE
Add version 1.0 value to dtmcs.version field

### DIFF
--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -73,6 +73,8 @@
             0: Version described in spec version 0.11.
 
             1: Version described in spec version 0.13.
+            
+            2: Version described in spec version 1.0.
 
             15: Version not described in any available version of this spec.
         </field>

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -72,9 +72,7 @@
         <field name="version" bits="3:0" access="R" reset="1">
             0: Version described in spec version 0.11.
 
-            1: Version described in spec version 0.13.
-            
-            2: Version described in spec version 1.0.
+            1: Version described in spec versions 0.13 and 1.0.
 
             15: Version not described in any available version of this spec.
         </field>


### PR DESCRIPTION
I noticed that dtmcs.version did not have a value specified to indicate spec version 1.0.