### PR TITLE
Update version of priv spec to one with hypervisor

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -41,7 +41,7 @@ no translation then it will be the same.
 \item The RISC-V Instruction Set Manual, Volume I: User-Level ISA, Document
     Version 2.2 (the ISA Spec)
 \item The RISC-V Instruction Set Manual, Volume II: Privileged Architecture,
-    Version 1.10 (the Privileged Spec)
+    Version 1.12 (the Privileged Spec)
 \end{steps}
 
 \subsection{Versions}


### PR DESCRIPTION
I was informed that the reference to the Privileged Spec is outdated and received a suggestion to change it to point to a version that includes hypervisor.