### PR TITLE
Use A-mode instead of "A mode" consistently.

### DIFF
--- a/core_debug.tex
+++ b/core_debug.tex
@@ -146,7 +146,7 @@ executed.
     \item \Rpc changes to the value stored in \RcsrDpc.
     \item The current privilege mode and virtualization mode are changed to that specified by
         \FcsrDcsrPrv and \FcsrDcsrV.
-    \item If the new privilege mode is less privileged than M mode,
+    \item If the new privilege mode is less privileged than M-mode,
         \FcsrMcontrolMprv in \Rmstatus is cleared.
     \item The hart is no longer in debug mode.
 \end{steps}

--- a/trigger.tex
+++ b/trigger.tex
@@ -148,17 +148,17 @@ the trace specification.
 Triggers can be used for native debugging. On a fully featured hart, triggers
 will be set using \FcsrMcontrolU or \FcsrMcontrolS, and when firing they can cause a breakpoint exception
 to trap to a more privileged mode. It is possible to set triggers natively to
-fire in M mode as well. In that case there is no higher privilege mode to trap
+fire in M-mode as well. In that case there is no higher privilege mode to trap
 to. When such a trigger causes a breakpoint exception while already in a trap
 handler, this might leave the hart unable to resume normal execution.
 
 On full-featured harts this is a remote corner case that can probably be
-ignored. On harts that only implement M mode, however, it is recommended to
+ignored. On harts that only implement M-mode, however, it is recommended to
 implement one of two solutions to this problem. This way triggers can be useful
-for native debugging of even M mode code.
+for native debugging of even M-mode code.
 
 The simple solution is to have the hardware prevent triggers with action=0 from
-firing while in M mode and while \FcsrMcontrolMie in \Rmstatus is 0. Its limitation is
+firing while in M-mode and while \FcsrMcontrolMie in \Rmstatus is 0. Its limitation is
 that interrupts might be disabled at other times when a user might want
 triggers to fire.
 
@@ -166,7 +166,7 @@ A more complex solution is to implement \FcsrTcontrolMte and \FcsrTcontrolMpte i
 solution has the benefit that it only disables triggers during the trap
 handler.
 
-A user setting M mode triggers that cause breakpoint exceptions will have to be
+A user setting M-mode triggers that cause breakpoint exceptions will have to be
 aware of any problems that might come up with the particular hart they are
 working on.
 

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -45,7 +45,7 @@
 
             1: {\tt ebreak} instructions in S-mode enter Debug Mode.
 
-            This bit is hardwired to 0 if the hart does not support S mode.
+            This bit is hardwired to 0 if the hart does not support S-mode.
         </field>
         <field name="ebreaku" bits="12" access="WARL" reset="0">
             0: {\tt ebreak} instructions in U-mode behave as described in the
@@ -53,7 +53,7 @@
 
             1: {\tt ebreak} instructions in U-mode enter Debug Mode.
 
-            This bit is hardwired to 0 if the hart does not support U mode.
+            This bit is hardwired to 0 if the hart does not support U-mode.
         </field>
         <field name="stepie" bits="11" access="WARL" reset="0">
             0: Interrupts (including NMI) are disabled during single stepping.

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -119,7 +119,7 @@
     </register>
 
     <register name="Trigger Control" short="tcontrol" address="0x7a5">
-        This optional register is only accessible in M mode and Debug Mode and
+        This optional register is only accessible in M-mode and Debug Mode and
         provides various control bits related to triggers.
 
         <field name="0" bits="XLEN-1:10" access="R" reset="0" />
@@ -165,7 +165,7 @@
     </register>
 
     <register name="Hypervisor Context" short="hcontext" address="0x6a8">
-        This optional register is only accessible in S/HS mode, M mode and
+        This optional register is only accessible in S/HS-mode, M-mode and
         Debug Mode.
 
         If the H extension is not implemented then this register is not
@@ -186,8 +186,8 @@
     </register>
 
     <register name="Supervisor Context" short="scontext" address="0x5a8">
-        This optional register is only accessible in S/HS mode, VS mode,
-        M mode and Debug Mode.
+        This optional register is only accessible in S/HS-mode, VS-mode,
+        M-mode and Debug Mode.
 
         <field name="data" bits="XLEN-1:0" access="WARL" reset="0">
             Supervisor mode software can write a context number to this
@@ -202,7 +202,7 @@
 
     <register name="Machine Context" short="mcontext" address="0x7a8">
         This optional register is an alias for \RcsrHcontext and is only
-        accessible in M mode and Debug mode.
+        accessible in M-mode and Debug mode.
     </register>
 
     <register name="Machine Supervisor Context" short="mscontext" address="0x7aa">


### PR DESCRIPTION
This is also what the privileged spec does.