### PR TITLE
Move dret completely into the appendix.

### DIFF
--- a/core_debug.tex
+++ b/core_debug.tex
@@ -33,8 +33,8 @@ How Debug Mode is implemented is not specified here.
     timers are stopped.
 \item The {\tt wfi} instruction acts as a {\tt nop}.
 \item Almost all instructions that change the privilege level have \unspecified\ 
-    behavior.  This includes {\tt ecall}, {\tt mret}, {\tt sret}, {\tt uret},
-    and {\tt dret}.  (To change the privilege level, the debugger can write
+    behavior.  This includes {\tt ecall}, {\tt mret}, {\tt sret}, and {\tt uret}.
+    (To change the privilege level, the debugger can write
     \FcsrDcsrPrv and \FcsrDcsrV in \RcsrDcsr). The only exception is {\tt ebreak}, which ends
     execution of the Program Buffer when executed.
 \item All control transfer instructions may act as illegal instructions if
@@ -148,17 +148,6 @@ executed.
         \FcsrMcontrolMprv in \Rmstatus is cleared.
     \item The hart is no longer in debug mode.
 \end{steps}
-
-\section{{\tt dret} Instruction} \label{dret}
-
-To assist with certain types of implementations (see \ref{execution_based}),
-a new instruction is defined: {\tt dret}. It has an encoding of 0x7b200073.
-
-Execution of this instruction in the program buffer causes \unspecified\ behavior.
-Executing {\tt dret} outside of Debug Mode causes an illegal instruction exception.
-
-It is defined in this specification only to reserve the opcode and
-allow for reusable Debug Module implementations.
 
 \section{XLEN}
 

--- a/implementations.tex
+++ b/implementations.tex
@@ -62,6 +62,9 @@ write to \RdmDataZero, take effect before the DM returns \FdmAbstractcsBusy
 to 0.
 
 To resume execution, the debug module sets a flag which causes the hart to execute a {\tt dret}.
+{\tt dret} is an instruction that only has meaning while in Debug Mode and
+not executing from the Program Buffer.
+Its recommended encoding is 0x7b200073.
 When {\tt dret} is executed, \Rpc is restored from \RcsrDpc and normal execution resumes at the
 privilege set by \FcsrDcsrPrv.
 


### PR DESCRIPTION
Suggested by Ken Dockser, since dret has no meaning outside specific
implementations.