### PR TITLE
Divide the spec into ISA and non-ISA.

### DIFF
--- a/core_debug.tex
+++ b/core_debug.tex
@@ -1,4 +1,4 @@
-\chapter{RISC-V Debug}
+\chapter{RISC-V Debug, ISA}
 \label{sec:core_debug}
 
 Modifications to the RISC-V core to support debug are kept to a minimum.  There

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -1,4 +1,4 @@
-\chapter{Debug Module (DM)} \label{dm}
+\chapter{Debug Module (DM), non-ISA} \label{dm}
 
 \begin{steps}{The Debug Module implements a translation interface between abstract debug
     operations and their specific implementation. It might support the following

--- a/dtm.tex
+++ b/dtm.tex
@@ -1,4 +1,4 @@
-\chapter{Debug Transport Module (DTM)} \label{dtm}
+\chapter{Debug Transport Module (DTM), non-ISA} \label{dtm}
 
 Debug Transport Modules provide access to the DM over one or more transports
 (e.g.\ JTAG or USB).

--- a/introduction.tex
+++ b/introduction.tex
@@ -178,10 +178,16 @@ incompatible, but unlikely to be noticeable:}
 \subsection{Structure}
 
 This document contains two parts. The main part of the document is the
-specification, which is given in the numbered sections. The second part
-of the document is a set of  appendices. The information
+specification, which is given in the numbered chapters. The second part
+of the document is a set of appendices. The information
 in the appendices is intended to clarify and provide examples, but is
 not part of the actual specification.
+
+\subsection{ISA vs. non-ISA}
+
+This specification consists of both ISA and non-ISA parts. Chapters whose
+contents are solely one or the other are labeled as such in their title.
+Chapters without such a label apply to both ISA and non-ISA
 
 \subsection{Register Definition Format}
 

--- a/introduction.tex
+++ b/introduction.tex
@@ -185,9 +185,10 @@ not part of the actual specification.
 
 \subsection{ISA vs. non-ISA}
 
-This specification consists of both ISA and non-ISA parts. Chapters whose
-contents are solely one or the other are labeled as such in their title.
-Chapters without such a label apply to both ISA and non-ISA
+This specification consists of both ISA and non-ISA parts. ISA parts specify
+hart state and behavior. Non-ISA parts specify non-hart state and behavior.
+Chapters whose contents are solely one or the other are labeled as such in their
+title. Chapters without such a label apply to both ISA and non-ISA
 
 \subsection{Register Definition Format}
 

--- a/trigger.tex
+++ b/trigger.tex
@@ -1,4 +1,4 @@
-\chapter{Trigger Module (TM)}
+\chapter{Trigger Module (TM), ISA}
 \label{sec:trigger}
 
 Triggers can cause a breakpoint exception, entry into Debug Mode, or a trace action


### PR DESCRIPTION
There are separate definition-of-done requirements for ISA vs. non-ISA
specs. Our spec contains both, so clearly mark what is what.