### PR TITLE
Labels must come after (or in) their caption.

### DIFF
--- a/trigger.tex
+++ b/trigger.tex
@@ -94,7 +94,6 @@ in the chain.
 
 \begin{table}[H]
 \centering
-\label{tab:priority}
 \begin{tabular}{|l|r|l|l|}
   \hline
   Priority      & Exception & Description & Trigger \\
@@ -126,6 +125,7 @@ in the chain.
   \hline
 \end{tabular}
 \caption{Synchronous exception priority in decreasing priority order.}
+\label{tab:priority}
 \end{table}
 
 When multiple triggers in the same priority fire at once, \FcsrMcontrolHit (if


### PR DESCRIPTION
Fixes #639.