### PR TITLE
Stoptime clarification per architecture review

### DIFF
--- a/Sdext.tex
+++ b/Sdext.tex
@@ -32,8 +32,9 @@ How Debug Mode is implemented is not specified here.
 \item No action is taken if a trigger matches.
 \item If \FcsrDcsrStopcount is 0 then counters continue. If it is 1 then
     counters are stopped.
-\item If \FcsrDcsrStoptime is 0 then timers continue. If it is 1 then
-    timers are stopped.
+\item If \FcsrDcsrStoptime is 0 then the time CSR continues to update. If
+    it is 1 then the time CSR will not update. It will resynchronize with
+    mtime after leaving Debug Mode.
 \item The {\tt wfi} instruction acts as a {\tt nop}.
 \item Almost all instructions that change the privilege level have \unspecified\ 
     behavior.  This includes {\tt ecall}, {\tt mret}, {\tt sret}, and {\tt uret}.

--- a/Sdext.tex
+++ b/Sdext.tex
@@ -32,9 +32,9 @@ How Debug Mode is implemented is not specified here.
 \item No action is taken if a trigger matches.
 \item If \FcsrDcsrStopcount is 0 then counters continue. If it is 1 then
     counters are stopped.
-\item If \FcsrDcsrStoptime is 0 then the time CSR continues to update. If
-    it is 1 then the time CSR will not update. It will resynchronize with
-    mtime after leaving Debug Mode.
+\item If \FcsrDcsrStoptime is 0 then \Rtime continues to update. If
+    it is 1 then \Rtime will not update. It will resynchronize with
+    \Rmtime after leaving Debug Mode.
 \item The {\tt wfi} instruction acts as a {\tt nop}.
 \item Almost all instructions that change the privilege level have \unspecified\ 
     behavior.  This includes {\tt ecall}, {\tt mret}, {\tt sret}, and {\tt uret}.

--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -23,6 +23,7 @@
 \deffieldname{\Fmxl}{MXL}
 \defregname{\Rmisa}{misa}
 \defregname{\Rmtime}{mtime}
+\defregname{\Rtime}{time}
 \defregname{\Rmstatus}{mstatus}
 \defregname{\Rsstatus}{sstatus}
 \defregname{\Rvsstatus}{vsstatus}

--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -22,6 +22,7 @@
 \deffieldname{\FcsrSstatusSie}{SIE}
 \deffieldname{\Fmxl}{MXL}
 \defregname{\Rmisa}{misa}
+\defregname{\Rmtime}{mtime}
 \defregname{\Rmstatus}{mstatus}
 \defregname{\Rsstatus}{sstatus}
 \defregname{\Rvsstatus}{vsstatus}

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -80,7 +80,9 @@
         <field name="stoptime" bits="9" access="WARL" reset="Preset">
             0: Increment the time CSR as usual.
 
-            1: Don't increment the time CSR while in Debug Mode.
+            1: Don't increment the time CSR while in Debug Mode.  If all harts
+            have \FcsrDcsrStoptime=1 and are in Debug Mode then the \Rmtime
+            register is also allowed to stop incrementing.
 
             An implementation may hardwire this bit to 0 or 1.
         </field>

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -78,11 +78,11 @@
             An implementation may hardwire this bit to 0 or 1.
         </field>
         <field name="stoptime" bits="9" access="WARL" reset="Preset">
-            0: Increment the time CSR as usual.
+            0: Increment \Rtime as usual.
 
-            1: Don't increment the time CSR while in Debug Mode.  If all harts
-            have \FcsrDcsrStoptime=1 and are in Debug Mode then the \Rmtime
-            register is also allowed to stop incrementing.
+            1: Don't increment \Rtime while in Debug Mode.  If all harts
+            have \FcsrDcsrStoptime=1 and are in Debug Mode then \Rmtime
+            is also allowed to stop incrementing.
 
             An implementation may hardwire this bit to 0 or 1.
         </field>

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -78,9 +78,9 @@
             An implementation may hardwire this bit to 0 or 1.
         </field>
         <field name="stoptime" bits="9" access="WARL" reset="Preset">
-            0: Increment timers as usual.
+            0: Increment the time CSR as usual.
 
-            1: Don't increment any hart-local timers while in Debug Mode.
+            1: Don't increment the time CSR while in Debug Mode.
 
             An implementation may hardwire this bit to 0 or 1.
         </field>


### PR DESCRIPTION
I was going to say that it should stop the time CSR plus any custom CSRs that the custom extension might want to stop.  But custom extensions can always define their behavior to depend on standard CSR bits like stoptime so I decided that this wouldn't add anything.
