### PR TITLE
Fix uses of \index macro.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -214,7 +214,7 @@ Halted harts ignore their halt request bit.
 When a debugger writes 1 to \FdmDmcontrolResumereq, each selected hart's resume ack bit is
 cleared and each selected, halted hart is sent a resume request. Harts respond
 by resuming, clearing their halted signal, and asserting their running signal.
-At the end of this process the \index{resume ack bit} is set.  These
+At the end of this process the resume ack bit\index{resume ack bit} is set.  These
 status signals of all selected harts are reflected in \FdmDmstatusAllresumeack,
 \FdmDmstatusAnyresumeack, \FdmDmstatusAllrunning, and \FdmDmstatusAnyrunning. Resume requests are ignored by
 running harts.
@@ -261,7 +261,7 @@ other harts in the group are already halted.
 \item All the other harts in that group will quickly resume as soon as any
     currently executing abstract commands have completed, except for the harts
     that are in the process of halting.
-    Each hart in the group sets its \index{resume ack bit} as soon as it has resumed.
+    Each hart in the group sets its resume ack bit\index{resume ack bit} as soon as it has resumed.
 \item Any external triggers in that group are notified.
 \end{steps}
 Adding a hart to a resume group does not automatically resume that hart, even

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -39,11 +39,11 @@
         </field>
         <field name="allresumeack" bits="17" access="R" reset="-">
             This field is 1 when all currently selected harts have their
-            \index{resume ack bit} set.
+            resume ack bit\index{resume ack bit} set.
         </field>
         <field name="anyresumeack" bits="16" access="R" reset="-">
             This field is 1 when any currently selected hart has its
-            \index{resume ack bit} set.
+            resume ack bit\index{resume ack bit} set.
         </field>
         <field name="allnonexistent" bits="15" access="R" reset="-">
             This field is 1 when all currently selected harts do not exist in


### PR DESCRIPTION
The macro simply makes a reference for the index, but does not display
the internal text.