### PR TITLE
Clarify tmexttrigger with action=0.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -1026,7 +1026,15 @@
         sequentially).  Unsupported inputs are hardwired to be inactive.
 
         If the trigger fires with action=0 then zero is written to the
-        {\tt tval} CSR on the breakpoint trap.
+        {\tt tval} CSR on the breakpoint trap.  This trigger fires
+        asynchronously but it is subject to delegation by medeleg[3] like
+        the other triggers.
+
+        The external trigger input can signal when the trigger is prevented
+        from firing due to one of the mechanisms in section ~\ref{sec:nativetrigger}.
+        An implementation may either ignore the signal altogether when it cannot
+        fire (dropping the trigger event) or it may hold the action as pending
+        and fire the trigger once it is legal to do so.
         <field name="type" bits="XLEN-1:XLEN-4" access="R" reset="4" />
         <field name="dmode" bits="XLEN-5" access="WARL" reset="0" />
         <field name="hit" bits="XLEN-6" access="WARL" reset="0">


### PR DESCRIPTION
The privileged spec says that medeleg only delegates synchronous exceptions so clarify that in the case of tmexttrigger medeleg is delegating an asynchronous exception.

Also clarify what happens to tmexttrigger events that happen while the trigger is prevented from firing.