### PR TITLE
Trigger fires on NMI regardless of tdata2/3.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -989,7 +989,8 @@
         <field name="nmi" bits="10" access="WARL" reset="0">
             When set, non-maskable interrupts cause this
             trigger to fire, regardless of the values of \FcsrEtriggerM,
-            \FcsrEtriggerS, \FcsrEtriggerU, \FcsrEtriggerVs, and \FcsrEtriggerVu.
+            \FcsrEtriggerS, \FcsrEtriggerU, \FcsrEtriggerVs, \FcsrEtriggerVu,
+            \RcsrTdataTwo, and \RcsrTdataThree.
         </field>
         <field name="m" bits="9" access="WARL" reset="0">
             When set, enable this trigger for exceptions that are taken from M


### PR DESCRIPTION
I think that ignoring tdata2 was reasonably clear but that was not clear to someone I spoke to.  I think that ignoring tdata3 was always the intention but it's not stated anywhere.  These two extra words make it all very explicit.

I separately asked on the mailing list about moving this bit to itrigger but this PR does not do that.  This PR seems like the correct behavior regardless of where this bit lives.
