### PR TITLE
mte/mpte apply only to breakpoint traps

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -122,6 +122,7 @@ order to implement 1.0:}
     \item When a selected trigger is disabled, \RcsrTdataTwo and \RcsrTdataThree
     can be written with any value supported by any of the types this trigger
     supports. \PR{721}
+    \item \RcsrTcontrol fields only apply to breakpoint traps, not any trap. \PR{723}
 \end{steps}
 
 \subsubsection{Minor Changes from 0.13 to 1.0}

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -149,7 +149,7 @@
             regarding triggers with action=0 firing in M-mode trap handlers. See
             Section~\ref{sec:nativetrigger} for more details.
 
-            When a trap into M-mode is taken, \FcsrTcontrolMpte is set to the value of
+            When a breakpoint trap into M-mode is taken, \FcsrTcontrolMpte is set to the value of
             \FcsrTcontrolMte.
         </field>
         <field name="0" bits="6:4" access="R" reset="0" />
@@ -160,7 +160,7 @@
 
             1: Triggers do match/fire while the hart is in M-mode.
 
-            When a trap into M-mode is taken, \FcsrTcontrolMte is set to 0. When {\tt
+            When a breakpoint trap into M-mode is taken, \FcsrTcontrolMte is set to 0. When {\tt
             mret} is executed, \FcsrTcontrolMte is set to the value of \FcsrTcontrolMpte.
         </field>
         <field name="0" bits="2:0" access="R" reset="0" />


### PR DESCRIPTION
This makes it possible to use triggers to debug some of the exception
handling code as well.

See 2022 email subject:"trigger questions"