### PR TITLE
Add field values to XML register description.

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -79,8 +79,43 @@ class Register( object ):
     def __str__( self ):
         return self.name
 
+class Value( object ):
+    def __init__( self, element ):
+        self.value = element.get( 'v' )
+        self.range = element.get( 'range' )
+        if self.range:
+            self.low, self.high = self.range.split( ":" )
+        self.text = element.text.strip()
+        self.tail = element.tail.strip()
+        self.name = element.get( "name" )
+        self.duplicate = element.get( "duplicate" )
+
+    def to_latex( self ):
+        result = []
+        if self.range:
+            result.append("%s--%s (%s): %s\n" % ( self.low, self.high, self.name, self.text ))
+        else:
+            result.append("%s (%s): %s\n" % ( self.value, self.name, self.text ))
+        if self.tail:
+            result.append( self.tail )
+        return "\n".join( result )
+
+    def to_c_definitions( self, prefix ):
+        result = []
+        name = "%s_%s" % ( prefix, toCIdentifier( self.name.upper() ))
+        result.append(( "comment", "%s: %s" % ( self.name, self.text )))
+        if self.range:
+            result.append(( "%s_LOW" % name, self.low ))
+            result.append(( "%s_HIGH" % name, self.high ))
+        else:
+            result.append(( name, self.value ))
+        if self.tail:
+            result.append(( "comment", self.tail ))
+        return result
+
 class Field( object ):
-    def __init__( self, name, lowBit, highBit, reset, access, description, sdesc, define ):
+    def __init__( self, name, lowBit, highBit, reset, access, description,
+            sdesc, define, values ):
         self.name = name
         self.lowBit = lowBit
         self.highBit = highBit
@@ -88,6 +123,15 @@ class Field( object ):
         self.access = access
         self.description = description
         self.define = define
+        self.values = values
+
+        name_counts = collections.Counter( v.name for v in values if not v.duplicate )
+        assert all( v == 1 for v in name_counts.values() ), \
+            "Duplicate field name in field %s" % self.name
+
+        value_counts = collections.Counter( v.value for v in values if not v.duplicate )
+        assert all( v == 1 for v in value_counts.values() ), \
+            "Duplicate field value in field %s" % self.name
 
     def length( self ):
         return sympy.simplify( "1 + (%s) - (%s)" % ( self.highBit, self.lowBit ) )
@@ -100,6 +144,12 @@ class Field( object ):
             # Fancier would be to assume XLEN is 32 or something.
             l = 20
         return max( l, len( self.name ), len( self.lowBit + self.highBit ) * 1.2 )
+
+    def latex_description(self):
+        result = [self.description]
+        for value in self.values:
+            result.append(value.to_latex())
+        return "\n\n".join(result)
 
     def __str__( self ):
         return self.name
@@ -149,9 +199,10 @@ def parse_xml( path ):
                 define = int( f.get( 'define', '0' ) )
             else:
                 define = int( f.get( 'define', '1' ) )
+            values = [ Value( v ) for v in f.findall( 'value' ) ]
             field = Field( f.get( 'name' ), lowBit, highBit, f.get( 'reset' ),
                     f.get( 'access' ), description, f.get( 'sdesc' ),
-                    define )
+                    define, values )
             register.add_field( field )
 
         register.check()
@@ -273,23 +324,27 @@ def write_cheader( fd, registers ):
             if f.define:
                 if f.description:
                     definitions.append(( "comment", f.description ))
+                prefix = "%s_%s" % ( prefname, toCIdentifier( f.name ).upper() )
                 offset = Macro(
-                    "%s_%s_OFFSET" % ( prefname, toCIdentifier( f.name ).upper() ),
+                    "%s_OFFSET" % prefix,
                     f.lowBit
                 )
                 definitions.append(( offset.prototype(), offset.body() ))
                 length = Macro(
-                    "%s_%s_LENGTH" % ( prefname, toCIdentifier( f.name ).upper() ),
+                    "%s_LENGTH" % prefix,
                     f.length()
                 )
                 definitions.append(( length.prototype(), length.body() ))
                 # sympy doesn't support a bit shift (<<) operator, so here we
                 # use power (**) instead.
                 mask = Macro(
-                    "%s_%s" % ( prefname, toCIdentifier( f.name ).upper() ),
+                    prefix,
                     ((2 ** sympy.simplify(f.length())) - 1) * (2 ** sympy.simplify(f.lowBit))
                 )
                 definitions.append(( mask.prototype(), mask.body() ))
+
+                for v in f.values:
+                    definitions += v.to_c_definitions(prefix)
 
     counted = collections.Counter(name for name, value in definitions)
     for name, value in definitions:
@@ -512,12 +567,12 @@ def print_latex_custom( registers ):
 
             print("\\end{center}")
 
-        columns = [("l", "Field", "name")]
-        columns += [("p{0.5\\textwidth}", "Description", "description")]
+        columns = [("l", "Field", lambda f: f.name)]
+        columns += [("p{0.5\\textwidth}", "Description", lambda f: f.latex_description())]
         if not registers.skip_access:
-            columns += [("c", "Access", "access")]
+            columns += [("c", "Access", lambda f: f.access)]
         if not registers.skip_reset:
-            columns += [("l", "Reset", "reset")]
+            columns += [("l", "Reset", lambda f: f.reset)]
 
         if any( f.description for f in r.fields ):
             print("\\tabletail{\\hline \\multicolumn{%d}{|r|}" % len(columns))
@@ -535,11 +590,11 @@ def print_latex_custom( registers ):
             print("   \\endlastfoot")
 
             for f in r.fields:
-                if f.description:
+                if f.description or f.values:
                     print("\\label{%s}" % toLatexIdentifier(registers.prefix, r.short or r.label, f.name))
                     print("\\index{%s}" % f.name)
-                    print("   |%s| &" % str(getattr(f, columns[0][2])), end=' ')
-                    print("%s\\\\" % " & ".join(str(getattr(f, c[2])) for c in columns[1:]))
+                    print("   |%s| &" % str(columns[0][2](f)), end=' ')
+                    print("%s\\\\" % " & ".join(str(c[2](f)) for c in columns[1:]))
                     print("   \\hline")
 
             print("   \\end{longtable}")
@@ -608,6 +663,7 @@ def main():
     if not registers.skip_index:
         print_latex_index( registers )
     if parsed.register:
+        assert(0)
         print_latex_register( registers )
     if parsed.custom:
         print_latex_custom( registers )

--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -135,7 +135,7 @@
         </field>
         <field name="write" bits="16">
             When \FacAccessregisterTransfer is set:
-            <value v="0" name="arg">
+            <value v="0" name="arg0">
             Copy data from the specified register into {\tt arg0} portion
                of {\tt data}.
             </value>
@@ -263,7 +263,7 @@
         </field>
         <field name="0" bits="18:17" />
         <field name="write" bits="16">
-            <value v="0" name="arg">
+            <value v="0" name="arg0">
             Copy data from the memory location specified in {\tt arg1} into
             the low bits of {\tt arg0}. The value of the remaining bits of
             {\tt arg0} are \unspecified.

--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -75,15 +75,15 @@
         </field>
         <field name="0" bits="23" />
         <field name="aarsize" bits="22:20">
-            <value v="2" name="32">
+            <value v="2" name="32bit">
             Access the lowest 32 bits of the register.
             </value>
 
-            <value v="3" name="64">
+            <value v="3" name="64bit">
             Access the lowest 64 bits of the register.
             </value>
 
-            <value v="4" name="128">
+            <value v="4" name="128bit">
             Access the lowest 128 bits of the register.
             </value>
 
@@ -233,23 +233,23 @@
             that same abstract command with \FacAccessmemoryAamvirtual cleared.
         </field>
         <field name="aamsize" bits="22:20">
-            <value v="0" name="8">
+            <value v="0" name="8bit">
             Access the lowest 8 bits of the memory location.
             </value>
 
-            <value v="1" name="16">
+            <value v="1" name="16bit">
             Access the lowest 16 bits of the memory location.
             </value>
 
-            <value v="2" name="32">
+            <value v="2" name="32bit">
             Access the lowest 32 bits of the memory location.
             </value>
 
-            <value v="3" name="64">
+            <value v="3" name="64bit">
             Access the lowest 64 bits of the memory location.
             </value>
 
-            <value v="4" name="128">
+            <value v="4" name="128bit">
             Access the lowest 128 bits of the memory location.
             </value>
         </field>

--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -265,8 +265,8 @@
         <field name="write" bits="16">
             <value v="0" name="arg">
             Copy data from the memory location specified in {\tt arg1} into
-            the low bits of {\tt arg0}. Any remaining bits of {\tt arg0} now
-            have an undefined value.
+            the low bits of {\tt arg0}. The value of the remaining bits of
+            {\tt arg0} are \unspecified.
             </value>
 
             <value v="1" name="memory">

--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -75,11 +75,17 @@
         </field>
         <field name="0" bits="23" />
         <field name="aarsize" bits="22:20">
-            2: Access the lowest 32 bits of the register.
+            <value v="2" name="32">
+            Access the lowest 32 bits of the register.
+            </value>
 
-            3: Access the lowest 64 bits of the register.
+            <value v="3" name="64">
+            Access the lowest 64 bits of the register.
+            </value>
 
-            4: Access the lowest 128 bits of the register.
+            <value v="4" name="128">
+            Access the lowest 128 bits of the register.
+            </value>
 
             If \FacAccessregisterAarsize specifies a size larger than the register's actual size,
             then the access must fail. If a register is accessible, then reads of \FacAccessregisterAarsize
@@ -91,37 +97,53 @@
             Table~\ref{tab:datareg}.
         </field>
         <field name="aarpostincrement" bits="19">
-            0: No effect. This variant must be supported.
+            <value v="0" name="disabled">
+            No effect. This variant must be supported.
+            </value>
 
-            1: After a successful register access, \FacAccessregisterRegno is
+            <value v="1" name="enabled">
+            After a successful register access, \FacAccessregisterRegno is
             incremented. Incrementing past the highest supported value
             causes \FacAccessregisterRegno to become \unspecified.  Supporting
             this variant is optional. It is undefined whether the increment
             happens when \FacAccessregisterTransfer is 0.
+            </value>
         </field>
         <field name="postexec" bits="18">
-            0: No effect. This variant must be supported, and is the only
+            <value v="0" name="disabled">
+            No effect. This variant must be supported, and is the only
             supported one if \FdmAbstractcsProgbufsize is 0.
+            </value>
 
-            1: Execute the program in the Program Buffer exactly once after
+            <value v="1" name="enabled">
+            Execute the program in the Program Buffer exactly once after
             performing the transfer, if any. Supporting this variant is
             optional.
+            </value>
         </field>
         <field name="transfer" bits = "17">
-            0: Don't do the operation specified by \FacAccessregisterWrite.
+            <value v="0" name="disabled">
+            Don't do the operation specified by \FacAccessregisterWrite.
+            </value>
 
-            1: Do the operation specified by \FacAccessregisterWrite.
+            <value v="1" name="enabled">
+            Do the operation specified by \FacAccessregisterWrite.
+            </value>
 
             This bit can be used to just execute the Program Buffer without
             having to worry about placing valid values into \FacAccessregisterAarsize or \FacAccessregisterRegno.
         </field>
         <field name="write" bits="16">
             When \FacAccessregisterTransfer is set:
-            0: Copy data from the specified register into {\tt arg0} portion
+            <value v="0" name="arg">
+            Copy data from the specified register into {\tt arg0} portion
                of {\tt data}.
+            </value>
 
-            1: Copy data from {\tt arg0} portion of {\tt data} into the
+            <value v="1" name="register">
+            Copy data from {\tt arg0} portion of {\tt data} into the
                specified register.
+            </value>
         </field>
         <field name="regno" bits="15:0">
           Number of the register to access, as described in
@@ -197,25 +219,39 @@
             physical accesses, but it must fail accesses that it doesn't
             support.
 
-            0: Addresses are physical (to the hart they are performed on).
+            <value v="0" name="physical">
+            Addresses are physical (to the hart they are performed on).
+            </value>
 
-            1: Addresses are virtual, and translated the way they would be from
+            <value v="1" name="virtual">
+            Addresses are virtual, and translated the way they would be from
             M-mode, with \FcsrMstatusMprv set.
+            </value>
 
             Debug Modules on systems without address translation (i.e. virtual addresses equal physical)
             may optionally allow \FacAccessmemoryAamvirtual set to 1, which would produce the same result as
             that same abstract command with \FacAccessmemoryAamvirtual cleared.
         </field>
         <field name="aamsize" bits="22:20">
-            0: Access the lowest 8 bits of the memory location.
+            <value v="0" name="8">
+            Access the lowest 8 bits of the memory location.
+            </value>
 
-            1: Access the lowest 16 bits of the memory location.
+            <value v="1" name="16">
+            Access the lowest 16 bits of the memory location.
+            </value>
 
-            2: Access the lowest 32 bits of the memory location.
+            <value v="2" name="32">
+            Access the lowest 32 bits of the memory location.
+            </value>
 
-            3: Access the lowest 64 bits of the memory location.
+            <value v="3" name="64">
+            Access the lowest 64 bits of the memory location.
+            </value>
 
-            4: Access the lowest 128 bits of the memory location.
+            <value v="4" name="128">
+            Access the lowest 128 bits of the memory location.
+            </value>
         </field>
         <field name="aampostincrement" bits="19">
             After a memory access has completed, if this bit is 1, increment
@@ -227,12 +263,16 @@
         </field>
         <field name="0" bits="18:17" />
         <field name="write" bits="16">
-            0: Copy data from the memory location specified in {\tt arg1} into
+            <value v="0" name="arg">
+            Copy data from the memory location specified in {\tt arg1} into
             the low bits of {\tt arg0}. Any remaining bits of {\tt arg0} now
             have an undefined value.
+            </value>
 
-            1: Copy data from the low bits of {\tt arg0} into the memory
+            <value v="1" name="memory">
+            Copy data from the low bits of {\tt arg0} into the memory
             location specified in {\tt arg1}.
+            </value>
         </field>
         <field name="target-specific" bits="15:14">
             These bits are reserved for target-specific uses.

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -148,7 +148,7 @@
             The hart single stepped because \FcsrDcsrStep was set. (priority 0, lowest)
             </value>
 
-            <value v="5" name="reset">
+            <value v="5" name="resethaltreq">
             The hart halted directly out of reset due to \Fresethaltreq. It
             is also acceptable to report 3 when this happens. (priority 2)
             </value>

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -8,57 +8,87 @@
         \end{commentary}
 
         <field name="debugver" bits="31:28" access="R" reset="Preset">
-          0: There is no debug support.
+            <value v="0" name="none">
+            There is no debug support.
+            </value>
 
-          4: Debug support exists as it is described in this document.
+            <value v="4" name="1.0">
+            Debug support exists as it is described in this document.
+            </value>
 
-          15: There is debug support, but it does not conform to any
-          available version of this spec.
+            <value v="15" name="custom">
+            There is debug support, but it does not conform to any
+            available version of this spec.
+            </value>
         </field>
         <field name="0" bits="27:18" access="R" reset="0" />
         <field name="ebreakvs" bits="17" access="WARL" reset="0">
-          0: {\tt ebreak} instructions in VS-mode behave as described in the
-          Privileged Spec.
+            <value v="0" name="exception">
+            {\tt ebreak} instructions in VS-mode behave as described in the
+            Privileged Spec.
+            </value>
 
-          1: {\tt ebreak} instructions in VS-mode enter Debug Mode.
+            <value v="1" name="debug mode">
+            {\tt ebreak} instructions in VS-mode enter Debug Mode.
+            </value>
 
-          This bit is hardwired to 0 if the hart does not support virtualization mode.
+            This bit is hardwired to 0 if the hart does not support virtualization mode.
         </field>
         <field name="ebreakvu" bits="16" access="WARL" reset="0">
-          0: {\tt ebreak} instructions in VU-mode behave as described in the
-          Privileged Spec.
+            <value v="0" name="exception">
+            {\tt ebreak} instructions in VU-mode behave as described in the
+            Privileged Spec.
+            </value>
 
-          1: {\tt ebreak} instructions in VU-mode enter Debug Mode.
+            <value v="1" name="debug mode">
+            {\tt ebreak} instructions in VU-mode enter Debug Mode.
+            </value>
 
-          This bit is hardwired to 0 if the hart does not support virtualization mode.
+            This bit is hardwired to 0 if the hart does not support virtualization mode.
         </field>
         <field name="ebreakm" bits="15" access="R/W" reset="0">
-            0: {\tt ebreak} instructions in M-mode behave as described in the
+            <value v="0" name="exception">
+            {\tt ebreak} instructions in M-mode behave as described in the
             Privileged Spec.
+            </value>
 
-            1: {\tt ebreak} instructions in M-mode enter Debug Mode.
+            <value v="1" name="debug mode">
+            {\tt ebreak} instructions in M-mode enter Debug Mode.
+            </value>
         </field>
         <field name="0" bits="14" access="R" reset="0" />
         <field name="ebreaks" bits="13" access="WARL" reset="0">
-            0: {\tt ebreak} instructions in S-mode behave as described in the
+            <value v="0" name="exception">
+            {\tt ebreak} instructions in S-mode behave as described in the
             Privileged Spec.
+            </value>
 
-            1: {\tt ebreak} instructions in S-mode enter Debug Mode.
+            <value v="1" name="debug mode">
+            {\tt ebreak} instructions in S-mode enter Debug Mode.
+            </value>
 
             This bit is hardwired to 0 if the hart does not support S-mode.
         </field>
         <field name="ebreaku" bits="12" access="WARL" reset="0">
-            0: {\tt ebreak} instructions in U-mode behave as described in the
+            <value v="0" name="exception">
+            {\tt ebreak} instructions in U-mode behave as described in the
             Privileged Spec.
+            </value>
 
-            1: {\tt ebreak} instructions in U-mode enter Debug Mode.
+            <value v="1" name="debug mode">
+            {\tt ebreak} instructions in U-mode enter Debug Mode.
+            </value>
 
             This bit is hardwired to 0 if the hart does not support U-mode.
         </field>
         <field name="stepie" bits="11" access="WARL" reset="0">
-            0: Interrupts (including NMI) are disabled during single stepping.
+            <value v="0" name="interrupts disabled">
+            Interrupts (including NMI) are disabled during single stepping.
+            </value>
 
-            1: Interrupts (including NMI) are enabled during single stepping.
+            <value v="1" name="interrupts enabled">
+            Interrupts (including NMI) are enabled during single stepping.
+            </value>
 
             Implementations may hard wire this bit to 0.
             In that case interrupt behavior can be emulated by the debugger.
@@ -67,22 +97,30 @@
             is running.
         </field>
         <field name="stopcount" bits="10" access="WARL" reset="Preset">
-            0: Increment counters as usual.
+            <value v="0" name="increment">
+            Increment counters as usual.
+            </value>
 
-            1: Don't increment any hart-local counters while in Debug Mode or
+            <value v="1" name="freeze">
+            Don't increment any hart-local counters while in Debug Mode or
             on {\tt ebreak} instructions that cause entry into Debug Mode.
             These counters include the {\tt instret} CSR. On single-hart cores
             {\tt cycle} should be stopped, but on multi-hart cores it must keep
             incrementing.
+            </value>
 
             An implementation may hardwire this bit to 0 or 1.
         </field>
         <field name="stoptime" bits="9" access="WARL" reset="Preset">
-            0: Increment \Rtime as usual.
+            <value v="0" name="ignore">
+            Increment \Rtime as usual.
+            </value>
 
-            1: Don't increment \Rtime while in Debug Mode.  If all harts
+            <value v="1" name="freeze">
+            Don't increment \Rtime while in Debug Mode.  If all harts
             have \FcsrDcsrStoptime=1 and are in Debug Mode then \Rmtime
             is also allowed to stop incrementing.
+            </value>
 
             An implementation may hardwire this bit to 0 or 1.
         </field>
@@ -93,20 +131,32 @@
             cycle, hardware should set \FcsrDcsrCause to the cause with the highest
             priority.
 
-            1: An {\tt ebreak} instruction was executed. (priority 3)
+            <value v="1" name="ebreak">
+            An {\tt ebreak} instruction was executed. (priority 3)
+            </value>
 
-            2: A Trigger Module trigger fired with action=1. (priority 4)
+            <value v="2" name="trigger">
+            A Trigger Module trigger fired with action=1. (priority 4)
+            </value>
 
-            3: The debugger requested entry to Debug Mode using \FdmDmcontrolHaltreq.
+            <value v="3" name="haltreq">
+            The debugger requested entry to Debug Mode using \FdmDmcontrolHaltreq.
             (priority 1)
+            </value>
 
-            4: The hart single stepped because \FcsrDcsrStep was set. (priority 0, lowest)
+            <value v="4" name="step">
+            The hart single stepped because \FcsrDcsrStep was set. (priority 0, lowest)
+            </value>
 
-            5: The hart halted directly out of reset due to \Fresethaltreq. It
+            <value v="5" name="reset">
+            The hart halted directly out of reset due to \Fresethaltreq. It
             is also acceptable to report 3 when this happens. (priority 2)
+            </value>
 
-            6: The hart halted because it's part of a halt group. (priority 5,
+            <value v="6" name="group">
+            The hart halted because it's part of a halt group. (priority 5,
             highest) Harts may report 3 for this cause instead.
+            </value>
 
             Other values are reserved for future use.
         </field>
@@ -119,9 +169,13 @@
           This bit is hardwired to 0 on harts that do not support virtualization mode.
         </field>
         <field name="mprven" bits="4" access="WARL" reset="Preset">
-            0: \FcsrMstatusMprv in \Rmstatus is ignored in Debug Mode.
+            <value v="0" name="disabled">
+            \FcsrMstatusMprv in \Rmstatus is ignored in Debug Mode.
+            </value>
 
-            1: \FcsrMstatusMprv in \Rmstatus takes effect in Debug Mode.
+            <value v="1" name="enabled">
+            \FcsrMstatusMprv in \Rmstatus takes effect in Debug Mode.
+            </value>
 
             Implementing this bit is optional. It may be tied to either 0 or 1.
 	</field>

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -97,7 +97,7 @@
             is running.
         </field>
         <field name="stopcount" bits="10" access="WARL" reset="Preset">
-            <value v="0" name="increment">
+            <value v="0" name="normal">
             Increment counters as usual.
             </value>
 
@@ -112,7 +112,7 @@
             An implementation may hardwire this bit to 0 or 1.
         </field>
         <field name="stoptime" bits="9" access="WARL" reset="Preset">
-            <value v="0" name="ignore">
+            <value v="0" name="normal">
             Increment \Rtime as usual.
             </value>
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -86,11 +86,11 @@
 
         <!-- Fields that apply to the entire DM. -->
         <field name="authenticated" bits="7" access="R" reset="Preset">
-            <value v="0" name="required">
+            <value v="0" name="false">
             Authentication is required before using the DM.
             </value>
 
-            <value v="1" name="passed">
+            <value v="1" name="true">
             The authentication check has passed.
             </value>
 
@@ -128,7 +128,7 @@
             </value>
         </field>
         <field name="version" bits="3:0" reset="3" access="R">
-            <value v="0" name="not present">
+            <value v="0" name="none">
             There is no Debug Module present.
             </value>
 
@@ -147,7 +147,7 @@
             specification.
             </value>
 
-            <value v="15" name="non-compliant">
+            <value v="15" name="custom">
             There is a Debug Module but it does not conform to any
             available version of this spec.
             </value>
@@ -453,6 +453,10 @@
         </field>
         <field name="0" bits="23:13" access="R" reset="0" />
         <field name="busy" bits="12" access="R" reset="0">
+            <value v="0" name="ready">
+            There is no abstract command currently being executed.
+            </value>
+
             <value v="1" name="busy">
             An abstract command is currently being executed.
             </value>
@@ -476,35 +480,35 @@
 
             This field only contains a valid value if \FdmAbstractcsBusy is 0.
 
-            <value v="0 " name="none">
+            <value v="0" name="none">
             No error.
             </value>
 
-            <value v="1 " name="busy">
+            <value v="1" name="busy">
             An abstract command was executing while \RdmCommand,
             \RdmAbstractcs, or \RdmAbstractauto was written, or when one
             of the {\tt data} or {\tt progbuf} registers was read or written.
             This status is only written if \FdmAbstractcsCmderr contains 0.
             </value>
 
-            <value v="2 " name="not supported">
+            <value v="2" name="not supported">
             The command in \RdmCommand is not supported.  It
             may be supported with different options set, but it will not be
             supported at a later time when the hart or system state are
             different.
             </value>
 
-            <value v="3 " name="exception">
+            <value v="3" name="exception">
             An exception occurred while executing the command
             (e.g.\ while executing the Program Buffer).
             </value>
 
-            <value v="4 " name="halt/resume">
+            <value v="4" name="halt/resume">
             The abstract command couldn't execute because the
             hart wasn't in the required state (running/halted), or unavailable.
             </value>
 
-            <value v="5 " name="bus">
+            <value v="5" name="bus">
             The abstract command failed due to a bus error (e.g.\ 
             alignment, access size, or timeout).
             </value>
@@ -837,7 +841,7 @@
 
     <register name="System Bus Access Control and Status" short="sbcs" address="0x38">
         <field name="sbversion" bits="31:29" access="R" reset="1">
-            <value v="0" name="old">
+            <value v="0" name="legacy">
             The System Bus interface conforms to mainline drafts of this
             spec older than 1 January, 2018.
             </value>

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -9,16 +9,24 @@
 
         <field name="0" bits="31:25" access="R" reset="0" />
         <field name="ndmresetpending" bits="24" access="R" reset="-">
-            0: Unimplemented, or \FdmDmcontrolNdmreset is zero and no ndmreset is currently 
+            <value v="0" name="false">
+            Unimplemented, or \FdmDmcontrolNdmreset is zero and no ndmreset is currently 
             in progress.
+            </value>
 
-            1: \FdmDmcontrolNdmreset is currently nonzero, or there is an ndmreset in progress.
+            <value v="1" name="true">
+            \FdmDmcontrolNdmreset is currently nonzero, or there is an ndmreset in progress.
+            </value>
         </field>
         <field name="stickyunavail" bits="23" access="R" reset="Preset">
-            0: The per-hart {\tt unavail} bits reflect the current state of the hart.
+            <value v="0" name="current">
+            The per-hart {\tt unavail} bits reflect the current state of the hart.
+            </value>
 
-            1: The per-hart {\tt unavail} bits are sticky. Once they are set, they will
+            <value v="1" name="sticky">
+            The per-hart {\tt unavail} bits are sticky. Once they are set, they will
             not clear until the debugger acknowledges them using \FdmDmcontrolAckunavail.
+            </value>
         </field>
         <field name="impebreak" bits="22" access="R" reset="Preset">
             If 1, then there is an implicit {\tt ebreak} instruction at the
@@ -78,19 +86,27 @@
 
         <!-- Fields that apply to the entire DM. -->
         <field name="authenticated" bits="7" access="R" reset="Preset">
-            0: Authentication is required before using the DM.
+            <value v="0" name="required">
+            Authentication is required before using the DM.
+            </value>
 
-            1: The authentication check has passed.
+            <value v="1" name="passed">
+            The authentication check has passed.
+            </value>
 
             On components that don't implement authentication, this bit must be
             preset as 1.
         </field>
         <field name="authbusy" bits="6" access="R" reset="0">
-            0: The authentication module is ready to process the next
+            <value v="0" name="ready">
+            The authentication module is ready to process the next
             read/write to \RdmAuthdata.
+            </value>
 
-            1: The authentication module is busy. Accessing \RdmAuthdata results
+            <value v="1" name="busy">
+            The authentication module is busy. Accessing \RdmAuthdata results
             in unspecified behavior.
+            </value>
 
             \FdmDmstatusAuthbusy only becomes set in immediate response to an access to
             \RdmAuthdata.
@@ -101,26 +117,40 @@
             0 otherwise.
         </field>
         <field name="confstrptrvalid" bits="4" reset="Preset" access="R">
-            0: \RdmConfstrptrZero--\RdmConfstrptrThree hold information which
+            <value v="0" name="invalid">
+            \RdmConfstrptrZero--\RdmConfstrptrThree hold information which
             is not relevant to the configuration structure.
+            </value>
 
-            1: \RdmConfstrptrZero--\RdmConfstrptrThree hold the address of the
+            <value v="1" name="valid">
+            \RdmConfstrptrZero--\RdmConfstrptrThree hold the address of the
             configuration structure.
+            </value>
         </field>
         <field name="version" bits="3:0" reset="3" access="R">
-            0: There is no Debug Module present.
+            <value v="0" name="not present">
+            There is no Debug Module present.
+            </value>
 
-            1: There is a Debug Module and it conforms to version 0.11 of this
+            <value v="1" name="0.11">
+            There is a Debug Module and it conforms to version 0.11 of this
             specification.
+            </value>
 
-            2: There is a Debug Module and it conforms to version 0.13 of this
+            <value v="2" name="0.13">
+            There is a Debug Module and it conforms to version 0.13 of this
             specification.
+            </value>
 
-            3: There is a Debug Module and it conforms to version 1.0 of this
+            <value v="3" name="1.0">
+            There is a Debug Module and it conforms to version 1.0 of this
             specification.
+            </value>
 
-            15: There is a Debug Module but it does not conform to any
+            <value v="15" name="non-compliant">
+            There is a Debug Module but it does not conform to any
             available version of this spec.
+            </value>
         </field>
     </register>
 
@@ -203,27 +233,39 @@
             Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
         <field name="ackhavereset" bits="28" access="W1" reset="-">
-            0: No effect.
+            <value v="0" name="nop">
+            No effect.
+            </value>
 
-            1: Clears {\tt havereset} for any selected harts.
+            <value v="1" name="ack">
+            Clears {\tt havereset} for any selected harts.
+            </value>
 
             Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
         <field name="ackunavail" bits="27" access="W1" reset="-">
-            0: No effect.
+            <value v="0" name="nop">
+            No effect.
+            </value>
 
-            1: Clears {\tt unavail} for any selected harts that are currently available.
+            <value v="1" name="ack">
+            Clears {\tt unavail} for any selected harts that are currently available.
+            </value>
 
             Writes apply to the new value of \Fhartsel and \FdmDmcontrolHasel.
         </field>
         <field name="hasel" bits="26" access="WARL" reset="0">
             Selects the definition of currently selected harts.
 
-            0: There is a single currently selected hart, that is selected by \Fhartsel.
+            <value v="0" name="single">
+            There is a single currently selected hart, that is selected by \Fhartsel.
+            </value>
 
-            1: There may be multiple currently selected harts -- the hart
+            <value v="1" name="multiple">
+            There may be multiple currently selected harts -- the hart
             selected by \Fhartsel, plus those selected by the hart array mask
             register.
+            </value>
 
             An implementation which does not implement the hart array mask register
             must tie this field to 0. A debugger which wishes to use the hart array
@@ -288,13 +330,17 @@
             take an arbitrarily long time to complete activation or deactivation and will
             indicate completion by setting \FdmDmcontrolDmactive to the requested value.
 
-            0: The module's state, including authentication mechanism,
+            <value v="0" name="inactive">
+            The module's state, including authentication mechanism,
             takes its reset values (the \FdmDmcontrolDmactive bit is the only bit which can
             be written to something other than its reset value). Any accesses
             to the module may fail. Specifically, \FdmDmstatusVersion might not return
             correct data.
+            </value>
 
-            1: The module functions normally.
+            <value v="1" name="active">
+            The module functions normally.
+            </value>
 
             No other mechanism should exist that may result in resetting the
             Debug Module after power up.
@@ -330,12 +376,16 @@
         </field>
         <field name="0" bits="19:17" access="R" reset="0" />
         <field name="dataaccess" bits="16" access="R" reset="Preset">
-            0: The {\tt data} registers are shadowed in the hart by CSRs.
+            <value v="0" name="csr">
+            The {\tt data} registers are shadowed in the hart by CSRs.
             Each CSR is DXLEN bits in size, and corresponds
             to a single argument, per Table~\ref{tab:datareg}.
+            </value>
 
-            1: The {\tt data} registers are shadowed in the hart's memory map.
+            <value v="1" name="memory">
+            The {\tt data} registers are shadowed in the hart's memory map.
             Each register takes up 4 bytes in the memory map.
+            </value>
         </field>
         <field name="datasize" bits="15:12" access="R" reset="Preset">
             If \FdmHartinfoDataaccess is 0: Number of CSRs dedicated to
@@ -403,7 +453,9 @@
         </field>
         <field name="0" bits="23:13" access="R" reset="0" />
         <field name="busy" bits="12" access="R" reset="0">
-            1: An abstract command is currently being executed.
+            <value v="1" name="busy">
+            An abstract command is currently being executed.
+            </value>
 
             This bit is set as soon as \RdmCommand is written, and is
             not cleared until that command has completed.
@@ -424,30 +476,46 @@
 
             This field only contains a valid value if \FdmAbstractcsBusy is 0.
 
-            0 (none): No error.
+            <value v="0 " name="none">
+            No error.
+            </value>
 
-            1 (busy): An abstract command was executing while \RdmCommand,
+            <value v="1 " name="busy">
+            An abstract command was executing while \RdmCommand,
             \RdmAbstractcs, or \RdmAbstractauto was written, or when one
             of the {\tt data} or {\tt progbuf} registers was read or written.
             This status is only written if \FdmAbstractcsCmderr contains 0.
+            </value>
 
-            2 (not supported): The command in \RdmCommand is not supported.  It
+            <value v="2 " name="not supported">
+            The command in \RdmCommand is not supported.  It
             may be supported with different options set, but it will not be
             supported at a later time when the hart or system state are
             different.
+            </value>
 
-            3 (exception): An exception occurred while executing the command
+            <value v="3 " name="exception">
+            An exception occurred while executing the command
             (e.g.\ while executing the Program Buffer).
+            </value>
 
-            4 (halt/resume): The abstract command couldn't execute because the
+            <value v="4 " name="halt/resume">
+            The abstract command couldn't execute because the
             hart wasn't in the required state (running/halted), or unavailable.
+            </value>
 
-            5 (bus): The abstract command failed due to a bus error (e.g.\ 
+            <value v="5 " name="bus">
+            The abstract command failed due to a bus error (e.g.\ 
             alignment, access size, or timeout).
+            </value>
 
-            6: Reserved for future use.
+            <value v="6" name="reserved">
+            Reserved for future use.
+            </value>
 
-            7 (other): The command failed for another reason.
+            <value v="7" name="other">
+            The command failed for another reason.
+            </value>
         </field>
         <field name="0" bits="7:4" access="R" reset="0"/>
         <field name="datacount" bits="3:0" access="R" reset="Preset">
@@ -646,9 +714,13 @@
 
         <field name="0" bits="31:12" access="R" reset="0" />
         <field name="grouptype" bits="11" access="WARL" reset="0">
-            0: The remaining fields in this register configure halt groups.
+            <value v="0" name="halt">
+            The remaining fields in this register configure halt groups.
+            </value>
 
-            1: The remaining fields in this register configure resume groups.
+            <value v="1" name="resume">
+            The remaining fields in this register configure resume groups.
+            </value>
         </field>
         <field name="dmexttrigger" bits="10:7" access="WARL" reset="0">
             This field contains the currently selected DM external trigger.
@@ -689,9 +761,13 @@
             Writing 0 has no effect.
         </field>
         <field name="hgselect" bits="0" access="WARL" reset="0">
-            0: Operate on harts.
+            <value v="0" name="harts">
+            Operate on harts.
+            </value>
 
-            1: Operate on DM external triggers.
+            <value v="1" name="triggers">
+            Operate on DM external triggers.
+            </value>
 
             If there are no DM external triggers, this field must be tied to 0.
         </field>
@@ -761,10 +837,14 @@
 
     <register name="System Bus Access Control and Status" short="sbcs" address="0x38">
         <field name="sbversion" bits="31:29" access="R" reset="1">
-            0: The System Bus interface conforms to mainline drafts of this
+            <value v="0" name="old">
+            The System Bus interface conforms to mainline drafts of this
             spec older than 1 January, 2018.
+            </value>
 
-            1: The System Bus interface conforms to this version of the spec.
+            <value v="1" name="1.0">
+            The System Bus interface conforms to this version of the spec.
+            </value>
 
             Other values are reserved for future versions.
         </field>
@@ -795,15 +875,25 @@
         <field name="sbaccess" bits="19:17" access="R/W" reset="2">
             Select the access size to use for system bus accesses.
 
-            0: 8-bit
+            <value v="0" name="8">
+            8-bit
+            </value>
 
-            1: 16-bit
+            <value v="1" name="16">
+            16-bit
+            </value>
 
-            2: 32-bit
+            <value v="2" name="32">
+            32-bit
+            </value>
 
-            3: 64-bit
+            <value v="3" name="64">
+            64-bit
+            </value>
 
-            4: 128-bit
+            <value v="4" name="128">
+            128-bit
+            </value>
 
             If \FdmSbcsSbaccess has an unsupported value when the DM starts a bus
             access, the access is not performed and \FdmSbcsSberror is set to 4.
@@ -825,17 +915,29 @@
 
             An implementation may report ``Other'' (7) for any error condition.
 
-            0: There was no bus error.
+            <value v="0" name="none">
+            There was no bus error.
+            </value>
 
-            1: There was a timeout.
+            <value v="1" name="timeout">
+            There was a timeout.
+            </value>
 
-            2: A bad address was accessed.
+            <value v="2" name="address">
+            A bad address was accessed.
+            </value>
 
-            3: There was an alignment error.
+            <value v="3" name="alignment">
+            There was an alignment error.
+            </value>
 
-            4: An access of unsupported size was requested.
+            <value v="4" name="size">
+            An access of unsupported size was requested.
+            </value>
 
-            7: Other.
+            <value v="7" name="other">
+            Other.
+            </value>
         </field>
         <field name="sbasize" bits="11:5" access="R" reset="Preset">
             Width of system bus addresses in bits. (0 indicates there is no bus

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -879,23 +879,23 @@
         <field name="sbaccess" bits="19:17" access="R/W" reset="2">
             Select the access size to use for system bus accesses.
 
-            <value v="0" name="8">
+            <value v="0" name="8bit">
             8-bit
             </value>
 
-            <value v="1" name="16">
+            <value v="1" name="16bit">
             16-bit
             </value>
 
-            <value v="2" name="32">
+            <value v="2" name="32bit">
             32-bit
             </value>
 
-            <value v="3" name="64">
+            <value v="3" name="64bit">
             64-bit
             </value>
 
-            <value v="4" name="128">
+            <value v="4" name="128bit">
             128-bit
             </value>
 

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -1271,18 +1271,18 @@
             Ignore \FcsrTextraThirtytwoMhvalue.
             </value>
 
-            <value v="4" name="equal">
+            <value v="4" name="mcontext">
             This trigger will only match if the low bits of
             \RcsrMcontext/\RcsrHcontext equal \FcsrTextraThirtytwoMhvalue.
             </value>
 
-            1, 5: This trigger will only match if the low bits of
+            1, 5 (mcontext\_select): This trigger will only match if the low bits of
             \RcsrMcontext/\RcsrHcontext equal \{\FcsrTextraThirtytwoMhvalue, mhselect[2]\}.
 
-            2, 6: This trigger will only match if VMID in hgatp equals the lower VMIDMAX
+            2, 6 (vmid\_select): This trigger will only match if VMID in hgatp equals the lower VMIDMAX
             (defined in the Privileged Spec) bits of \{\FcsrTextraThirtytwoMhvalue, mhselect[2]\}.
 
-            3, 7: Reserved.
+            3, 7 (reserved): Reserved.
 
             If the H extension is not supported, the only legal values are 0 and 4.
         </field>
@@ -1306,12 +1306,12 @@
             Ignore \FcsrTextraThirtytwoSvalue.
             </value>
 
-            <value v="1" name="equal">
+            <value v="1" name="scontext">
             This trigger will only match if the low bits of
             \RcsrScontext equal \FcsrTextraThirtytwoSvalue.
             </value>
 
-            <value v="2" name="vequal">
+            <value v="2" name="asid">
             This trigger will only match if:
             \begin{itemize}[noitemsep,nolistsep]
             \item the mode is VS-mode or VU-mode and ASID in \Rvsatp

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -41,37 +41,57 @@
         disable it by changing \FcsrTdataOneType to 15.
 
         <field name="type" bits="XLEN-1:XLEN-4" access="WARL" reset="Preset">
-            0: There is no trigger at this \RcsrTselect.
+            <value v="0" name="none">
+            There is no trigger at this \RcsrTselect.
+            </value>
 
-            1: The trigger is a legacy SiFive address match trigger. These
+            <value v="1" name="legacy">
+            The trigger is a legacy SiFive address match trigger. These
             should not be implemented and aren't further documented here.
+            </value>
 
-            2: The trigger is an address/data match trigger. The remaining bits
+            <value v="2" name="mcontrol">
+            The trigger is an address/data match trigger. The remaining bits
             in this register act as described in \RcsrMcontrol.
+            </value>
 
-            3: The trigger is an instruction count trigger. The remaining bits
+            <value v="3" name="icount">
+            The trigger is an instruction count trigger. The remaining bits
             in this register act as described in \RcsrIcount.
+            </value>
 
-            4: The trigger is an interrupt trigger. The remaining bits
+            <value v="4" name="itrigger">
+            The trigger is an interrupt trigger. The remaining bits
             in this register act as described in \RcsrItrigger.
+            </value>
 
-            5: The trigger is an exception trigger. The remaining bits
+            <value v="5" name="etrigger">
+            The trigger is an exception trigger. The remaining bits
             in this register act as described in \RcsrEtrigger.
+            </value>
 
-            6: The trigger is an address/data match trigger. The remaining bits
+            <value v="6" name="mcontrol6">
+            The trigger is an address/data match trigger. The remaining bits
             in this register act as described in \RcsrMcontrolSix. This is similar
             to a type 2 trigger, but provides additional functionality and
             should be used instead of type 2 in newer implementations.
+            </value>
 
-            7: The trigger is a trigger source external to the TM.  The
+            <value v="7" name="tmexttrigger">
+            The trigger is a trigger source external to the TM.  The
             remaining bits in this register act as described in \RcsrTmexttrigger.
+            </value>
 
-            12--14: These trigger types are available for non-standard use.
+            <value range="12:14" name="custom">
+            These trigger types are available for non-standard use.
+            </value>
 
-            15: This trigger is disabled. In this state, \RcsrTdataTwo and
+            <value v="15" name="disabled">
+            This trigger is disabled. In this state, \RcsrTdataTwo and
             \RcsrTdataThree can be written with any value that is supported for
             any of the types this trigger implements. The remaining bits in this
             register are ignored.
+            </value>
             
             Other values are reserved for future use.
 
@@ -79,11 +99,15 @@
         <field name="dmode" bits="XLEN-5" access="WARL" reset="0">
             If \FcsrTdataOneType is 0, then this bit is hard-wired to 0.
 
-            0: Both Debug and M-mode can write the {\tt tdata} registers at the
+            <value v="0" name="both">
+            Both Debug and M-mode can write the {\tt tdata} registers at the
             selected \RcsrTselect.
+            </value>
 
-            1: Only Debug Mode can write the {\tt tdata} registers at the
+            <value v="1" name="dmode">
+            Only Debug Mode can write the {\tt tdata} registers at the
             selected \RcsrTselect.  Writes from other modes are ignored.
+            </value>
 
             This bit is only writable from Debug Mode.
             In ordinary use, external debuggers will always set this bit when
@@ -156,9 +180,13 @@
         <field name="mte" bits="3" access="WARL" reset="0">
             M-mode trigger enable field.
 
-            0: Triggers with action=0 do not match/fire while the hart is in M-mode.
+            <value v="0" name="disabled">
+                Triggers with action=0 do not match/fire while the hart is in M-mode.
+            </value>
 
-            1: Triggers do match/fire while the hart is in M-mode.
+            <value v="1" name="enabled">
+                Triggers do match/fire while the hart is in M-mode.
+            </value>
 
             When a breakpoint trap into M-mode is taken, \FcsrTcontrolMte is set to 0. When {\tt
             mret} is executed, \FcsrTcontrolMte is set to the value of \FcsrTcontrolMpte.
@@ -309,19 +337,24 @@
         <field name="select" bits="19" access="WARL" reset="0">
             This bit determines the contents of the XLEN-bit compare values.
 
-            0: There is at least one compare value and it contains the lowest
+            <value v="0" name="address">
+            There is at least one compare value and it contains the lowest
             virtual address of the access.
             It is recommended that there are additional compare values for
             the other accessed virtual addresses.
             (E.g. on a 32-bit read from 0x4000, the lowest address is 0x4000
             and the other addresses are 0x4001, 0x4002, and 0x4003.)
+            </value>
 
-            1: There is exactly one compare value and it contains the data
+            <value v="1" name="data">
+            There is exactly one compare value and it contains the data
             value loaded or stored, or the instruction executed.
             Any bits beyond the size of the data access will contain 0.
+            </value>
         </field>
         <field name="timing" bits="18" access="WARL" reset="0">
-            0: The action for this trigger will be taken just before the
+            <value v="0" name="before">
+            The action for this trigger will be taken just before the
             instruction that triggered it is committed, but after all preceding
             instructions are committed. \Rxepc or \RcsrDpc (depending
             on \FcsrMcontrolAction) must be set to the virtual address of the
@@ -333,14 +366,17 @@
             though the load will not update its destination register. Debuggers
             should consider this when setting such breakpoints on, for example,
             memory-mapped I/O addresses.
+            </value>
 
-            1: The action for this trigger will be taken after the instruction
+            <value v="1" name="after">
+            The action for this trigger will be taken after the instruction
             that triggered it is committed. It should be taken before the next
             instruction is committed, but it is better to implement triggers imprecisely
             than to not implement them at all.  \Rxepc or
             \RcsrDpc (depending on \FcsrMcontrolAction) must be set to
             the virtual address of the next instruction that must be executed to
             preserve the program flow.
+            </value>
 
             Most hardware will only implement one timing or the other, possibly
             dependent on \FcsrMcontrolSelect, \FcsrMcontrolExecute,
@@ -362,31 +398,51 @@
             This field contains the 2 low bits of the access size. The high bits come
             from \FcsrMcontrolSizehi. The combined value is interpreted as follows:
 
-            0: The trigger will attempt to match against an access of any size.
+            <value v="0" name="any">
+            The trigger will attempt to match against an access of any size.
             The behavior is only well-defined if $|select|=0$, or if the access
             size is XLEN.
+            </value>
 
-            1: The trigger will only match against 8-bit memory accesses.
+            <value v="1" name="8">
+            The trigger will only match against 8-bit memory accesses.
+            </value>
 
-            2: The trigger will only match against 16-bit memory accesses or
+            <value v="2" name="16">
+            The trigger will only match against 16-bit memory accesses or
             execution of 16-bit instructions.
+            </value>
 
-            3: The trigger will only match against 32-bit memory accesses or
+            <value v="3" name="32">
+            The trigger will only match against 32-bit memory accesses or
             execution of 32-bit instructions.
+            </value>
 
-            4: The trigger will only match against execution of 48-bit instructions.
+            <value v="4" name="48">
+            The trigger will only match against execution of 48-bit instructions.
+            </value>
 
-            5: The trigger will only match against 64-bit memory accesses or
+            <value v="5" name="64">
+            The trigger will only match against 64-bit memory accesses or
             execution of 64-bit instructions.
+            </value>
 
-            6: The trigger will only match against execution of 80-bit instructions.
+            <value v="6" name="80">
+            The trigger will only match against execution of 80-bit instructions.
+            </value>
 
-            7: The trigger will only match against execution of 96-bit instructions.
+            <value v="7" name="96">
+            The trigger will only match against execution of 96-bit instructions.
+            </value>
 
-            8: The trigger will only match against execution of 112-bit instructions.
+            <value v="8" name="112">
+            The trigger will only match against execution of 112-bit instructions.
+            </value>
 
-            9: The trigger will only match against 128-bit memory accesses or
+            <value v="9" name="128">
+            The trigger will only match against 128-bit memory accesses or
             execution of 128-bit instructions.
+            </value>
 
             An implementation must support the value of 0, but all other values
             are optional. When an implementation supports address triggers
@@ -410,10 +466,14 @@
             in Table~\ref{tab:action}.
         </field>
         <field name="chain" bits="11" access="WARL" reset="0">
-            0: When this trigger matches, the configured action is taken.
+            <value v="0" name="disabled">
+            When this trigger matches, the configured action is taken.
+            </value>
 
-            1: While this trigger does not match, it prevents the trigger with
+            <value v="1" name="enabled">
+            While this trigger does not match, it prevents the trigger with
             the next index from matching.
+            </value>
 
             A trigger chain starts on the first trigger with $|chain|=1$ after
             a trigger with $|chain|=0$, or simply on the first trigger if that
@@ -439,39 +499,59 @@
             \FcsrMcontrolChain in writes to \RcsrMcontrol that would make the chain too long.
         </field>
         <field name="match" bits="10:7" access="WARL" reset="0">
-            0: Matches when any compare value equals \RcsrTdataTwo.
+            <value v="0" name="equal">
+            Matches when any compare value equals \RcsrTdataTwo.
+            </value>
 
-            1: Matches when the top $M$ bits of any compare value match the top
+            <value v="1" name="napot">
+            Matches when the top $M$ bits of any compare value match the top
             $M$ bits of \RcsrTdataTwo.
             $M$ is $|XLEN|-1$ minus the index of the least-significant
             bit containing 0 in \RcsrTdataTwo. Debuggers should only write values
             to \RcsrTdataTwo such that $M + $\FcsrMcontrolMaskmax$ \geq |XLEN|$
             and $M\gt0$ , otherwise it's undefined on what conditions the
             trigger will match.
+            </value>
 
-            2: Matches when any compare value is greater than (unsigned) or
+            <value v="2" name="ge">
+            Matches when any compare value is greater than (unsigned) or
             equal to \RcsrTdataTwo.
+            </value>
 
-            3: Matches when any compare value is less than (unsigned)
+            <value v="3" name="lt">
+            Matches when any compare value is less than (unsigned)
             \RcsrTdataTwo.
+            </value>
 
-            4: Matches when $\frac{|XLEN|}{2}-1$:$0$ of any compare value
+            <value v="4" name="mask low">
+            Matches when $\frac{|XLEN|}{2}-1$:$0$ of any compare value
             equals $\frac{|XLEN|}{2}-1$:$0$ of \RcsrTdataTwo after
             $\frac{|XLEN|}{2}-1$:$0$ of the compare value is ANDed with
             $|XLEN|-1$:$\frac{|XLEN|}{2}$ of \RcsrTdataTwo.
+            </value>
 
-            5: Matches when $|XLEN|-1$:$\frac{|XLEN|}{2}$ of any compare
+            <value v="5" name="mask high">
+            Matches when $|XLEN|-1$:$\frac{|XLEN|}{2}$ of any compare
             value equals $\frac{|XLEN|}{2}-1$:$0$ of \RcsrTdataTwo after
             $|XLEN|-1$:$\frac{|XLEN|}{2}$ of the compare value is ANDed with
             $|XLEN|-1$:$\frac{|XLEN|}{2}$ of \RcsrTdataTwo.
+            </value>
 
-            8: Matches when \FcsrMcontrolMatch$=0$ would not match.
+            <value v="8" name="not equal">
+            Matches when \FcsrMcontrolMatch$=0$ would not match.
+            </value>
 
-            9: Matches when \FcsrMcontrolMatch$=1$ would not match.
+            <value v="9" name="not napot">
+            Matches when \FcsrMcontrolMatch$=1$ would not match.
+            </value>
 
-            12: Matches when \FcsrMcontrolMatch$=4$ would not match.
+            <value v="12" name="not mask low">
+            Matches when \FcsrMcontrolMatch$=4$ would not match.
+            </value>
 
-            13: Matches when \FcsrMcontrolMatch$=5$ would not match.
+            <value v="13" name="not mask high">
+            Matches when \FcsrMcontrolMatch$=5$ would not match.
+            </value>
 
             Other values are reserved for future use.
 
@@ -620,19 +700,24 @@
         <field name="select" bits="21" access="WARL" reset="0">
             This bit determines the contents of the XLEN-bit compare values.
 
-            0: There is at least one compare value and it contains the lowest
+            <value v="0" name="address">
+            There is at least one compare value and it contains the lowest
             virtual address of the access.
             In addition, it is recommended that there are additional compare
             values for the other accessed virtual addresses match.
             (E.g. on a 32-bit read from 0x4000, the lowest address is 0x4000
             and the other addresses are 0x4001, 0x4002, and 0x4003.)
+            </value>
 
-            1: There is exactly one compare value and it contains the data
+            <value v="1" name="data">
+            There is exactly one compare value and it contains the data
             value loaded or stored, or the instruction executed.
             Any bits beyond the size of the data access will contain 0.
+            </value>
         </field>
         <field name="timing" bits="20" access="WARL" reset="0">
-            0: The action for this trigger will be taken just before the
+            <value v="0" name="before">
+            The action for this trigger will be taken just before the
             instruction that triggered it is committed, but after all preceding
             instructions are committed. \Rxepc or \RcsrDpc (depending
             on \FcsrMcontrolSixAction) must be set to the virtual address of the
@@ -644,14 +729,17 @@
             though the load will not update its destination register. Debuggers
             should consider this when setting such breakpoints on, for example,
             memory-mapped I/O addresses.
+            </value>
 
-            1: The action for this trigger will be taken after the instruction
+            <value v="1" name="after">
+            The action for this trigger will be taken after the instruction
             that triggered it is committed. It should be taken before the next
             instruction is committed, but it is better to implement triggers imprecisely
             than to not implement them at all.  \Rxepc or
             \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set to
             the virtual address of the next instruction that must be executed to
             preserve the program flow.
+            </value>
 
             Most hardware will only implement one timing or the other, possibly
             dependent on \FcsrMcontrolSixSelect, \FcsrMcontrolSixExecute,
@@ -670,31 +758,51 @@
             \FcsrMcontrolSixTiming of 1 matching as well.
         </field>
         <field name="size" bits="19:16" access="WARL" reset="0">
-            0: The trigger will attempt to match against an access of any size.
+            <value v="0" name="any">
+            The trigger will attempt to match against an access of any size.
             The behavior is only well-defined if $|select|=0$, or if the access
             size is XLEN.
+            </value>
 
-            1: The trigger will only match against 8-bit memory accesses.
+            <value v="1" name="8">
+            The trigger will only match against 8-bit memory accesses.
+            </value>
 
-            2: The trigger will only match against 16-bit memory accesses or
+            <value v="2" name="16">
+            The trigger will only match against 16-bit memory accesses or
             execution of 16-bit instructions.
+            </value>
 
-            3: The trigger will only match against 32-bit memory accesses or
+            <value v="3" name="32">
+            The trigger will only match against 32-bit memory accesses or
             execution of 32-bit instructions.
+            </value>
 
-            4: The trigger will only match against execution of 48-bit instructions.
+            <value v="4" name="48">
+            The trigger will only match against execution of 48-bit instructions.
+            </value>
 
-            5: The trigger will only match against 64-bit memory accesses or
+            <value v="5" name="64">
+            The trigger will only match against 64-bit memory accesses or
             execution of 64-bit instructions.
+            </value>
 
-            6: The trigger will only match against execution of 80-bit instructions.
+            <value v="6" name="80">
+            The trigger will only match against execution of 80-bit instructions.
+            </value>
 
-            7: The trigger will only match against execution of 96-bit instructions.
+            <value v="7" name="96">
+            The trigger will only match against execution of 96-bit instructions.
+            </value>
 
-            8: The trigger will only match against execution of 112-bit instructions.
+            <value v="8" name="112">
+            The trigger will only match against execution of 112-bit instructions.
+            </value>
 
-            9: The trigger will only match against 128-bit memory accesses or
+            <value v="9" name="128">
+            The trigger will only match against 128-bit memory accesses or
             execution of 128-bit instructions.
+            </value>
 
             An implementation must support the value of 0, but all other values
             are optional. When an implementation supports address triggers
@@ -718,10 +826,14 @@
             in Table~\ref{tab:action}.
         </field>
         <field name="chain" bits="11" access="WARL" reset="0">
-            0: When this trigger matches, the configured action is taken.
+            <value v="0" name="disabled">
+            When this trigger matches, the configured action is taken.
+            </value>
 
-            1: While this trigger does not match, it prevents the trigger with
+            <value v="1" name="enabled">
+            While this trigger does not match, it prevents the trigger with
             the next index from matching.
+            </value>
 
             A trigger chain starts on the first trigger with $|chain|=1$ after
             a trigger with $|chain|=0$, or simply on the first trigger if that
@@ -747,9 +859,12 @@
             \FcsrMcontrolSixChain in writes to \RcsrMcontrolSix that would make the chain too long.
         </field>
         <field name="match" bits="10:7" access="WARL" reset="0">
-            0: Matches when any compare value equals \RcsrTdataTwo.
+            <value v="0" name="equal">
+            Matches when any compare value equals \RcsrTdataTwo.
+            </value>
 
-            1: Matches when the top $M$ bits of any compare value match the top
+            <value v="1" name="napot">
+            Matches when the top $M$ bits of any compare value match the top
             $M$ bits of \RcsrTdataTwo.
             $M$ is $|XLEN|-1$ minus the index of the least-significant bit
             containing 0 in \RcsrTdataTwo.
@@ -758,30 +873,47 @@
             are \unspecified.
             Legal values for \RcsrTdataTwo require $M + |maskmax6| \geq |XLEN|$ and $M\gt0$.
             See above for how to determine maskmax6.
+            </value>
 
-            2: Matches when any compare value is greater than (unsigned) or
+            <value v="2" name="ge">
+            Matches when any compare value is greater than (unsigned) or
             equal to \RcsrTdataTwo.
+            </value>
 
-            3: Matches when any compare value is less than (unsigned)
+            <value v="3" name="lt">
+            Matches when any compare value is less than (unsigned)
             \RcsrTdataTwo.
+            </value>
 
-            4: Matches when $\frac{|XLEN|}{2}-1$:$0$ of any compare value
+            <value v="4" name="mask low">
+            Matches when $\frac{|XLEN|}{2}-1$:$0$ of any compare value
             equals $\frac{|XLEN|}{2}-1$:$0$ of \RcsrTdataTwo after
             $\frac{|XLEN|}{2}-1$:$0$ of the compare value is ANDed with
             $|XLEN|-1$:$\frac{|XLEN|}{2}$ of \RcsrTdataTwo.
+            </value>
 
-            5: Matches when $|XLEN|-1$:$\frac{|XLEN|}{2}$ of any compare
+            <value v="5" name="mask high">
+            Matches when $|XLEN|-1$:$\frac{|XLEN|}{2}$ of any compare
             value equals $\frac{|XLEN|}{2}-1$:$0$ of \RcsrTdataTwo after
             $|XLEN|-1$:$\frac{|XLEN|}{2}$ of the compare value is ANDed with
             $|XLEN|-1$:$\frac{|XLEN|}{2}$ of \RcsrTdataTwo.
+            </value>
 
-            8: Matches when \FcsrMcontrolSixMatch$=0$ would not match.
+            <value v="8" name="not equal">
+            Matches when \FcsrMcontrolSixMatch$=0$ would not match.
+            </value>
 
-            9: Matches when \FcsrMcontrolSixMatch$=1$ would not match.
+            <value v="9" name="not napot">
+            Matches when \FcsrMcontrolSixMatch$=1$ would not match.
+            </value>
 
-            12: Matches when \FcsrMcontrolSixMatch$=4$ would not match.
+            <value v="12" name="not mask low">
+            Matches when \FcsrMcontrolSixMatch$=4$ would not match.
+            </value>
 
-            13: Matches when \FcsrMcontrolSixMatch$=5$ would not match.
+            <value v="13" name="not mask high">
+            Matches when \FcsrMcontrolSixMatch$=5$ would not match.
+            </value>
 
             Other values are reserved for future use.
 
@@ -1135,10 +1267,14 @@
             Data used together with \FcsrTextraThirtytwoMhselect.
         </field>
         <field name="mhselect" bits="25:23" access="WARL" reset="0">
-            0: Ignore \FcsrTextraThirtytwoMhvalue.
+            <value v="0" name="ignore">
+            Ignore \FcsrTextraThirtytwoMhvalue.
+            </value>
 
-            4: This trigger will only match if the low bits of
+            <value v="4" name="equal">
+            This trigger will only match if the low bits of
             \RcsrMcontext/\RcsrHcontext equal \FcsrTextraThirtytwoMhvalue.
+            </value>
 
             1, 5: This trigger will only match if the low bits of
             \RcsrMcontext/\RcsrHcontext equal \{\FcsrTextraThirtytwoMhvalue, mhselect[2]\}.
@@ -1166,12 +1302,17 @@
             This field should be tied to 0 when S-mode is not supported.
         </field>
         <field name="sselect" bits="1:0" access="WARL" reset="0">
-            0: Ignore \FcsrTextraThirtytwoSvalue.
+            <value v="0" name="ignore">
+            Ignore \FcsrTextraThirtytwoSvalue.
+            </value>
 
-            1: This trigger will only match if the low bits of
+            <value v="1" name="equal">
+            This trigger will only match if the low bits of
             \RcsrScontext equal \FcsrTextraThirtytwoSvalue.
+            </value>
 
-            2: This trigger will only match if:
+            <value v="2" name="vequal">
+            This trigger will only match if:
             \begin{itemize}[noitemsep,nolistsep]
             \item the mode is VS-mode or VU-mode and ASID in \Rvsatp
             equals the lower ASIDMAX (defined in the Privileged Spec) bits
@@ -1180,6 +1321,7 @@
             ASIDMAX (defined in the Privileged Spec) bits of
             \FcsrTextraThirtytwoSvalue.
             \end{itemize}
+            </value>
 
             This field should be tied to 0 when S-mode is not supported.
         </field>

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -404,42 +404,42 @@
             size is XLEN.
             </value>
 
-            <value v="1" name="8">
+            <value v="1" name="8bit">
             The trigger will only match against 8-bit memory accesses.
             </value>
 
-            <value v="2" name="16">
+            <value v="2" name="16bit">
             The trigger will only match against 16-bit memory accesses or
             execution of 16-bit instructions.
             </value>
 
-            <value v="3" name="32">
+            <value v="3" name="32bit">
             The trigger will only match against 32-bit memory accesses or
             execution of 32-bit instructions.
             </value>
 
-            <value v="4" name="48">
+            <value v="4" name="48bit">
             The trigger will only match against execution of 48-bit instructions.
             </value>
 
-            <value v="5" name="64">
+            <value v="5" name="64bit">
             The trigger will only match against 64-bit memory accesses or
             execution of 64-bit instructions.
             </value>
 
-            <value v="6" name="80">
+            <value v="6" name="80bit">
             The trigger will only match against execution of 80-bit instructions.
             </value>
 
-            <value v="7" name="96">
+            <value v="7" name="96bit">
             The trigger will only match against execution of 96-bit instructions.
             </value>
 
-            <value v="8" name="112">
+            <value v="8" name="112bit">
             The trigger will only match against execution of 112-bit instructions.
             </value>
 
-            <value v="9" name="128">
+            <value v="9" name="128bit">
             The trigger will only match against 128-bit memory accesses or
             execution of 128-bit instructions.
             </value>
@@ -764,42 +764,42 @@
             size is XLEN.
             </value>
 
-            <value v="1" name="8">
+            <value v="1" name="8bit">
             The trigger will only match against 8-bit memory accesses.
             </value>
 
-            <value v="2" name="16">
+            <value v="2" name="16bit">
             The trigger will only match against 16-bit memory accesses or
             execution of 16-bit instructions.
             </value>
 
-            <value v="3" name="32">
+            <value v="3" name="32bit">
             The trigger will only match against 32-bit memory accesses or
             execution of 32-bit instructions.
             </value>
 
-            <value v="4" name="48">
+            <value v="4" name="48bit">
             The trigger will only match against execution of 48-bit instructions.
             </value>
 
-            <value v="5" name="64">
+            <value v="5" name="64bit">
             The trigger will only match against 64-bit memory accesses or
             execution of 64-bit instructions.
             </value>
 
-            <value v="6" name="80">
+            <value v="6" name="80bit">
             The trigger will only match against execution of 80-bit instructions.
             </value>
 
-            <value v="7" name="96">
+            <value v="7" name="96bit">
             The trigger will only match against execution of 96-bit instructions.
             </value>
 
-            <value v="8" name="112">
+            <value v="8" name="112bit">
             The trigger will only match against execution of 112-bit instructions.
             </value>
 
-            <value v="9" name="128">
+            <value v="9" name="128bit">
             The trigger will only match against 128-bit memory accesses or
             execution of 128-bit instructions.
             </value>

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -63,11 +63,17 @@
             The size of \FdmSbaddressZeroAddress in \RdtmDmi.
         </field>
         <field name="version" bits="3:0" access="R" reset="1">
-            0: Version described in spec version 0.11.
+            <value v="0" name="0.11">
+            Version described in spec version 0.11.
+            </value>
 
-            1: Version described in spec versions 0.13 and 1.0.
+            <value v="1" name="1.0">
+            Version described in spec versions 0.13 and 1.0.
+            </value>
 
-            15: Version not described in any available version of this spec.
+            <value v="15" name="undescribed">
+            Version not described in any available version of this spec.
+            </value>
         </field>
     </register>
 
@@ -104,26 +110,39 @@
         <field name="op" bits="1:0" access="R/W" reset="0">
             When the debugger writes this field, it has the following meaning:
 
-            0: Ignore \FdmSbdataZeroData and \FdmSbaddressZeroAddress. (nop)
+            <value v="0" name="nop">
+            Ignore \FdmSbdataZeroData and \FdmSbaddressZeroAddress.
 
             Don't send anything over the DMI during Update-DR.
             This operation should never result in a busy or error response.
             The address and data reported in the following Capture-DR
             are undefined.
+            </value>
 
-            1: Read from \FdmSbaddressZeroAddress. (read)
+            <value v="1" name="read">
+            Read from \FdmSbaddressZeroAddress.
+            </value>
 
-            2: Write \FdmSbdataZeroData to \FdmSbaddressZeroAddress. (write)
+            <value v="2" name="write">
+            Write \FdmSbdataZeroData to \FdmSbaddressZeroAddress.
+            </value>
 
-            3: Reserved.
+            <value v="3" name="reserved">
+            Reserved.
+            </value>
 
             When the debugger reads this field, it means the following:
 
-            0: The previous operation completed successfully.
+            <value v="0" name="success" duplicate="1">
+            The previous operation completed successfully.
+            </value>
 
-            1: Reserved.
+            <value v="1" name="reserved" duplicate="1">
+            Reserved.
+            </value>
 
-            2: A previous operation failed.  The data scanned into \RdtmDmi in
+            <value v="2" name="failed" duplicate="1">
+            A previous operation failed.  The data scanned into \RdtmDmi in
             this access will be ignored.  This status is sticky and can be
             cleared by writing \FdtmDtmcsDmireset in \RdtmDtmcs.
 
@@ -131,14 +150,17 @@
             There are no specified cases in which the DM would
             respond with an error, and DMI is not required to support
             returning errors.
+            </value>
 
-            3: An operation was attempted while a DMI request is still in
+            <value v="3" name="busy" duplicate="1">
+            An operation was attempted while a DMI request is still in
             progress. The data scanned into \RdtmDmi in this access will be
             ignored. This status is sticky and can be cleared by writing
             \FdtmDtmcsDmireset in \RdtmDtmcs. If a debugger sees this status, it
             needs to give the target more TCK edges between Update-DR and
             Capture-DR. The simplest way to do that is to add extra transitions
             in Run-Test/Idle.
+            </value>
         </field>
     </register>
 

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -71,7 +71,7 @@
             Version described in spec versions 0.13 and 1.0.
             </value>
 
-            <value v="15" name="undescribed">
+            <value v="15" name="custom">
             Version not described in any available version of this spec.
             </value>
         </field>


### PR DESCRIPTION
Generate constants in the C header for the values. E.g.
```
 #define CSR_TDATA1_TYPE_NONE                0
 #define CSR_TDATA1_TYPE_LEGACY              1
 #define CSR_TDATA1_TYPE_MCONTROL            2
 #define CSR_TDATA1_TYPE_ICOUNT              3
 ...
```
Make formatting slightly more consistent in the PDF.