### PR TITLE
Make data registers Message Registers.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -309,8 +309,8 @@ not as storage to be accessed later.
 \begin{commentary}
     A regular register can be used to implement an MR. In some FPGAs it is
     cheaper to trade off storage for muxes, and in that case the storage can be
-    duplicated (one set of flip-flops for sending and one for receiving) to
-    avoid having to implement muxes to read/write data from/to the correct side.
+    duplicated (one set of bits for sending and one for receiving) to avoid
+    having to implement muxes to read/write data from/to the correct side.
 \end{commentary}
 
 \section{Abstract Commands} \label{abstractcommands}

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -292,6 +292,27 @@ meaning it is never possible to halt or resume just a single hart. This is
 explicitly allowed. In that case it must be possible to discover the groups by
 using \RdmDmcsTwo even if it's not possible to change the configuration.
 
+\section{Message Registers}
+\label{sec:mr}
+
+Message Registers (MRs) are registers that are only used in a limited way,
+allowing for different implementations. They exist to let two sides communicate
+when the two sides already know who is the sender and who is the receiver.
+
+An MR implements read and write operations on two sides.  When one side reads an
+MR, and the last write was by the other side, then the result value of the read
+is the value last written by the other side.  When one side reads an MR, and the
+last write was by that same side, then the result value of the read is
+\unspecified.  Thus the MR can be used to exchange data with the other side, but
+not as storage to be accessed later.
+
+\begin{commentary}
+    A regular register can be used to implement an MR. In some FPGAs it is
+    cheaper to trade off storage for muxes, and in that case the storage can be
+    duplicated (one set of flip-flops for sending and one for receiving) to
+    avoid having to implement muxes to read/write data from/to the correct side.
+\end{commentary}
+
 \section{Abstract Commands} \label{abstractcommands}
 
 The DM supports a set of abstract commands, most of which
@@ -321,12 +342,12 @@ successful or not. Commands may fail because a hart is not halted, not running,
 unavailable, or because they encounter an error during execution.
 
 If the command takes arguments, the debugger
-must write them to the {\tt data} registers before writing to \RdmCommand. If a
+must write them to the {\tt data} MRs before writing to \RdmCommand. If a
 command returns results, the Debug Module must ensure they are placed
-in the {\tt data} registers before \FdmAbstractcsBusy is cleared.
-Which {\tt data} registers are used for the arguments is
+in the {\tt data} MRs before \FdmAbstractcsBusy is cleared.
+Which {\tt data} MRs are used for the arguments is
 described in Table~\ref{tab:datareg}.  In all cases the least-significant word
-is placed in the lowest-numbered {\tt data} register. The argument width
+is placed in the lowest-numbered {\tt data} MR. The argument width
 depends on the command being executed, and is DXLEN where not explicitly
 specified.
 

--- a/introduction.tex
+++ b/introduction.tex
@@ -56,6 +56,8 @@ functionality.
     \item[JTAG]
         Refers to work done by IEEE's Joint Test Action Group, described in
         IEEE 1149.1.
+    \item[MR]
+        Message Register, described in Section~\ref{sec:mr}.
     \item[NAPOT]
         Naturally Aligned Powers-Of-Two.
     \item[NMI]
@@ -190,6 +192,10 @@ incompatible, but unlikely to be noticeable:}
 called 1.0 stable.}
 \item \FcsrItriggerNmi was moved from \RcsrEtrigger to \RcsrItrigger, and is now
 subject to the mode bits in that trigger.
+\item DM {\tt data} registers are now Message Registers (see
+Section~\ref{sec:mr}). Debuggers must not assume they can read back the same
+value that they wrote, and must not assume that the result of the last abstract
+command is available as argument to the next abstract command. \PR{728}
 \end{steps}
 
 \section{About This Document}

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -344,6 +344,10 @@
             If \FdmHartinfoDataaccess is 1: Number of 32-bit words in the memory map
             dedicated to shadowing the {\tt data} registers.
 
+            If this value is non-zero, then the {tt data} registers must go
+            beyond being MRs and guarantee they store a single value, that is
+            readable/writable by either side.
+
             Since there are at most 12 {\tt data} registers, the value in this
             register must be 12 or smaller.
         </field>
@@ -558,18 +562,19 @@
     </register>
 
     <register name="Abstract Data 0" short="data0" address="0x04">
-        \RdmDataZero through \RdmDataEleven are basic read/write registers that may
+        \RdmDataZero through \RdmDataEleven are Message Registers, whose
+        behavior is described in Section~\ref{sec:mr}, that may
         be read or changed by abstract commands. \FdmAbstractcsDatacount indicates how many
         of them are implemented, starting at \RdmDataZero, counting up.
         Table~\ref{tab:datareg} shows how abstract commands use these
-        registers.
+        MRs.
 
-        Accessing these registers while an abstract command is executing causes
+        Accessing these MRs while an abstract command is executing causes
         \FdmAbstractcsCmderr to be set to 1 (busy) if it is 0.
 
         Attempts to write them while \FdmAbstractcsBusy is set does not change their value.
 
-        The values in these registers might not be preserved after an abstract
+        The values in these MRs might not be preserved after an abstract
         command is executed. The only guarantees on their contents are the ones
         offered by the command in question. If the command fails, no
         assumptions can be made about the contents of these registers.

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -345,7 +345,7 @@
             dedicated to shadowing the {\tt data} registers.
 
             If this value is non-zero, then the {tt data} registers must go
-            beyond being MRs and guarantee they store a single value, that is
+            beyond being MRs and guarantee they each store a single value, that is
             readable/writable by either side.
 
             Since there are at most 12 {\tt data} registers, the value in this


### PR DESCRIPTION
Message Registers allow data to be sent to the other side, but not to be
read back by the side that wrote the data.

This allows smaller FPGA implementations by duplicating the storage and
removing muxes in the design, addressing part of #717.

It is incompatible with old debuggers, if they use these registers in
surprising ways.