### PR TITLE
The program buffer may not be readable.

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -196,6 +196,8 @@ subject to the mode bits in that trigger.
 Section~\ref{sec:mr}). Debuggers must not assume they can read back the same
 value that they wrote, and must not assume that the result of the last abstract
 command is available as argument to the next abstract command. \PR{728}
+\item It may not be possible to read the contents of the Program Buffer using
+the {\tt progbuf} registers. \PR{731}
 \end{steps}
 
 \section{About This Document}

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -596,8 +596,12 @@
     <!-- =============== Program Buffer =============== -->
 
     <register name="Program Buffer 0" short="progbuf0" address="0x20">
-        \RdmProgbufZero through \RdmProgbufFifteen provide read/write access to the
-        optional program buffer. \FdmAbstractcsProgbufsize indicates how many of them are
+        \RdmProgbufZero through \RdmProgbufFifteen must provide write access to the
+        optional program buffer. It may also be possible for the debugger to
+        read from the program buffer through these registers. If reading
+        is not supported, then all reads return 0.
+
+        \FdmAbstractcsProgbufsize indicates how many {\tt progbuf} registers are
         implemented starting at \RdmProgbufZero, counting up.
 
         Accessing these registers while an abstract command is executing causes


### PR DESCRIPTION
This allows a more efficient implementation, especially on FPGAs.
See #717.