### PR TITLE
Add trigger action values, for debug_defines.h.

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -85,12 +85,14 @@ class Value( object ):
         self.range = element.get( 'range' )
         if self.range:
             self.low, self.high = self.range.split( ":" )
-        self.text = element.text.strip()
+        self.text = (element.text or "").strip()
         self.tail = element.tail.strip()
         self.name = element.get( "name" )
         self.duplicate = element.get( "duplicate" )
 
     def to_latex( self ):
+        if not self.text:
+            return ""
         result = []
         if self.range:
             result.append("%s--%s (%s): %s\n" % ( self.low, self.high, self.name, self.text ))
@@ -148,7 +150,9 @@ class Field( object ):
     def latex_description(self):
         result = [self.description]
         for value in self.values:
-            result.append(value.to_latex())
+            text = value.to_latex()
+            if text:
+                result.append(text)
         return "\n\n".join(result)
 
     def __str__( self ):

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -464,6 +464,14 @@
         <field name="action" bits="15:12" access="WARL" reset="0">
             The action to take when the trigger fires. The values are explained
             in Table~\ref{tab:action}.
+
+            <value v="0" name="breakpoint" />
+            <value v="1" name="debug mode" />
+            <value v="2" name="trace on" />
+            <value v="3" name="trace off" />
+            <value v="4" name="trace notify" />
+            <value v="8" name="external0" />
+            <value v="9" name="external1" />
         </field>
         <field name="chain" bits="11" access="WARL" reset="0">
             <value v="0" name="disabled">
@@ -824,6 +832,14 @@
         <field name="action" bits="15:12" access="WARL" reset="0">
             The action to take when the trigger fires. The values are explained
             in Table~\ref{tab:action}.
+
+            <value v="0" name="breakpoint" />
+            <value v="1" name="debug mode" />
+            <value v="2" name="trace on" />
+            <value v="3" name="trace off" />
+            <value v="4" name="trace notify" />
+            <value v="8" name="external0" />
+            <value v="9" name="external1" />
         </field>
         <field name="chain" bits="11" access="WARL" reset="0">
             <value v="0" name="disabled">
@@ -1049,6 +1065,14 @@
         <field name="action" bits="5:0" access="WARL" reset="0">
             The action to take when the trigger fires. The values are explained
             in Table~\ref{tab:action}.
+
+            <value v="0" name="breakpoint" />
+            <value v="1" name="debug mode" />
+            <value v="2" name="trace on" />
+            <value v="3" name="trace off" />
+            <value v="4" name="trace notify" />
+            <value v="8" name="external0" />
+            <value v="9" name="external1" />
         </field>
     </register>
 
@@ -1123,6 +1147,14 @@
         <field name="action" bits="5:0" access="WARL" reset="0">
             The action to take when the trigger fires. The values are explained
             in Table~\ref{tab:action}.
+
+            <value v="0" name="breakpoint" />
+            <value v="1" name="debug mode" />
+            <value v="2" name="trace on" />
+            <value v="3" name="trace off" />
+            <value v="4" name="trace notify" />
+            <value v="8" name="external0" />
+            <value v="9" name="external1" />
         </field>
     </register>
 
@@ -1191,6 +1223,14 @@
         <field name="action" bits="5:0" access="WARL" reset="0">
             The action to take when the trigger fires. The values are explained
             in Table~\ref{tab:action}.
+
+            <value v="0" name="breakpoint" />
+            <value v="1" name="debug mode" />
+            <value v="2" name="trace on" />
+            <value v="3" name="trace off" />
+            <value v="4" name="trace notify" />
+            <value v="8" name="external0" />
+            <value v="9" name="external1" />
         </field>
     </register>
 
@@ -1236,6 +1276,14 @@
         <field name="action" bits="5:0" access="WARL" reset="0">
             The action to take when the trigger fires. The values are explained
             in Table~\ref{tab:action}.
+
+            <value v="0" name="breakpoint" />
+            <value v="1" name="debug mode" />
+            <value v="2" name="trace on" />
+            <value v="3" name="trace off" />
+            <value v="4" name="trace notify" />
+            <value v="8" name="external0" />
+            <value v="9" name="external1" />
         </field>
     </register>
 


### PR DESCRIPTION
Leave the descriptions empty, and change registers.py to not emit
anything for values whose descriptions are empty.

I'm not a huge fan of the duplication of those values in the XML file,
but I don't want to invent a new mechanism to avoid it right now. (Ooh,
we could use M4 to generate the XML and use an existing mechanism...)