### PR TITLE
Add GitHub Action to auto release.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Rebuild and Publish PDF
+on:
+  push:
+    tags:
+      - 'v[0-9].[0-9]*-**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get install python3-sympy texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-extra texlive-science
+      - name: Build Stable
+        if: contains(github.ref, 'stable')
+        run: |
+          make stable
+      - name: Publish Stable
+        uses: softprops/action-gh-release@v1
+        if: contains(github.ref, 'stable')
+        with:
+          files: riscv-debug-stable.pdf
+      - name: Build Release
+        if: contains(github.ref, 'release')
+        run: |
+          make release
+      - name: Build Draft
+        if: contains(github.ref, 'draft')
+        run: |
+          make draft
+      - name: Publish Draft
+        uses: softprops/action-gh-release@v1
+        if: contains(github.ref, 'draft')
+        with:
+          files: riscv-debug-draft.pdf
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        if: contains(github.ref, 'release')
+        with:
+          files: riscv-debug-release.pdf
+

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,5 +10,4 @@ jobs:
                 sudo apt-get install python3-sympy texlive-latex-base \
                         texlive-latex-recommended texlive-latex-extra \
                         texlive-fonts-extra texlive-science
-            - run: make
-            - run: make chisel
+            - run: make draft stable release chisel


### PR DESCRIPTION
In this PR, I prototype a flow to automatically rebuild pdf and releasing CI, and use git tag to release new version of debug spec, which was discussed in 2022-05-10 Debug Task Group Call. Ask @timsifive for review.

Here is the new release strategy: For pdfs which need to be rebuilt: tag it with `v{version}-{stable|release|draft}`, for example `v0.13-release`, CI will automatically rebuild and send it to GitHub release page.

There current status of debug spec is: `v0.13` is released, `v1.0` is stable or draft(I'm not so sure about this), but not released yet. we need to have at least two tags: `v0.13-release` and `v1.0-stable` for the releasing procedure.

For the `v0.13-release`, we need to backport(rebase) this PR to 0.13(currently 4e0bb0fc2d843473db2356623792c6b7603b94d4 and [release](https://github.com/riscv/riscv-debug-spec/tree/release) branch).

I have these proposals(not request, just IMO, these might be good for downstreams/readers/users):
1. creating a new branches for `v0.13`, `v1.0` to disambiguates the debug-spec version.
2. making `master`(the main development branch) to be `v1.1-draft`, or some similar thing, which may introduce breaking change to `v1.0-stable`. for non-breaking changes, a backport can be automatically rebased to `v1.0-stable` with mergify.
3. use https://rtyley.github.io/bfg-repo-cleaner/ to clean up the history pdf blob, rebase from root, and force push the entire project. This can significantly reduce the repository size, but will rewrite all history, thus commit references to this repository will be broken.