### PR TITLE
Remove clarifying information that is false.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -633,8 +633,4 @@ are offsets from this base address.
 When read, unimplemented or non-existent Debug Module DMI Registers return 0.
 Writing them has no effect.
 
-For each register it is possible to determine that it is implemented by reading
-it and getting a non-zero value (e.g.\ \RdmSbcs), or by checking bits in another
-register (e.g.\ \FdmAbstractcsProgbufsize).
-
 \input{dm_registers.tex}


### PR DESCRIPTION
Specifically, it wasn't true for abstractauto.