### PR TITLE
Clarify writing 1 to action on dmode=0

### DIFF
--- a/Sdtrig.tex
+++ b/Sdtrig.tex
@@ -66,8 +66,8 @@ Value & Description \\
 
     This action is only legal when the trigger's \FcsrTdataOneDmode is 1.
     Since the {\tt tdata} registers are WARL, hardware should clear the action
-    field whenever the action field is 1, \FcsrTdataOneDmode is cleared, and the
-    new value of the action field would also be 1. \\
+    field whenever the action field is 1, the new value of \FcsrTdataOneDmode would be 0, and the
+    new value of the action field would be 1. \\
 \hline
 2 & Trace on, described in the trace specification. \\
 \hline


### PR DESCRIPTION
**Clarify/Simplify the sentence:**
 - Since the tdata registers are WARL, hardware should clear the action
field whenever the action field is 1, dmode is cleared, and the new
value of the action field would also be 1.

**Change into:**
 - If dmode is 0, writing 1 to the action clears the action field.

Reference: https://github.com/riscv/riscv-debug-spec/issues/746