### PR TITLE
abstractcs.relaxedpriv: Clarify the description

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -476,8 +476,13 @@
            permission checks (e.g. PMP restrictions are ignored).  The
            details of the latter are implementation-specific.
 
-           When set to 0, full permission checks apply. When set to 1,
-           relaxed permission checks apply.
+           <value v="0" name="full checks">
+           Full permission checks apply.
+           </value>
+           
+           <value v="1" name="relaxed checks">
+           Relaxed permission checks apply.
+           </value>
         </field>
         <field name="cmderr" bits="10:8" access="R/W1C" reset="0">
             Gets set if an abstract command fails. The bits in this field remain set until

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -474,8 +474,10 @@
            permission checks that apply based on the current architectural
            state of the hart performing the access, or with a relaxed set of
            permission checks (e.g. PMP restrictions are ignored).  The
-           details of the latter are implementation-specific.  When set to 0,
-           full permissions apply; when set to 1, relaxed permissions apply.
+           details of the latter are implementation-specific.
+
+           When set to 0, full permission checks apply. When set to 1,
+           relaxed permission checks apply.
         </field>
         <field name="cmderr" bits="10:8" access="R/W1C" reset="0">
             Gets set if an abstract command fails. The bits in this field remain set until


### PR DESCRIPTION
Changed the wording in the description of "abstractcs.relaxedpriv" because the original wording was unclear and could have been mis-interpreted:

Changes made:

- full permissions --> full permission checks
- relaxed permissions --> relaxed permission checks
