### PR TITLE
Clarify the term "trap" in execution-based implementations.

### DIFF
--- a/implementations.tex
+++ b/implementations.tex
@@ -30,8 +30,9 @@ When the halt request bit is set, the Debug Module raises a special interrupt
 to the selected harts. This interrupt causes each
 hart to enter Debug Mode and jump to a defined
 memory region that is serviced by the DM and is only accessible to the harts in Debug Mode.
-When taking this trap, \Rpc is saved to \RcsrDpc and \FcsrDcsrCause is updated
-in \RcsrDcsr.
+When taking this jump, \Rpc is saved to \RcsrDpc and \FcsrDcsrCause is updated
+in \RcsrDcsr.  This jump is similar to a trap but it is not architecturally
+considered a trap as that term is used in the rest of this document.
 
 The code in the Debug Module causes the hart to execute a ``park loop.''
 In the park loop the hart writes its \Rmhartid to a
@@ -51,7 +52,7 @@ otherwise the DM causes a {\tt ebreak} to execute immediately.
 
 When {\tt ebreak} is executed (indicating the end of the
 Program Buffer code) the hart returns to its park loop. If an exception is
-encountered, the hart jumps to a debug trap address within
+encountered, the hart jumps to an address within
 the Debug Module. The code there causes the hart to
 write to the Debug Module indicating an exception.
 Then the hart jumps back to the park loop.

--- a/implementations.tex
+++ b/implementations.tex
@@ -32,7 +32,7 @@ hart to enter Debug Mode and jump to a defined
 memory region that is serviced by the DM and is only accessible to the harts in Debug Mode.
 When taking this jump, \Rpc is saved to \RcsrDpc and \FcsrDcsrCause is updated
 in \RcsrDcsr.  This jump is similar to a trap but it is not architecturally
-considered a trap as that term is used in the rest of this document.
+considered a trap, so for instance doesn't count as a trap for trigger behavior.
 
 The code in the Debug Module causes the hart to execute a ``park loop.''
 In the park loop the hart writes its \Rmhartid to a


### PR DESCRIPTION
Say that you have an icount trigger enabled but icount.pending=0 and you have an execute trigger on the instruction pointed to by dpc.  You leave debug mode.  This will hit the execute trigger (which is higher priority than icount since pending=0) and immediately enter debug mode again.  What happens with icount.pending?

If this reentry to debug mode is considered a trap from some regular mode to debug mode then icount.pending would be set even though you didn't execute an instruction and you didn't take a "trap" as defined in the privileged spec.  That leads to a forward-progress problem because you didn't advance pc to the next instruction, a branch/jump target, or a trap handler (as defined in the priv spec).  There would also be no trap in a more abstract implementation where communication between the hart and DM is done via wires/buses rather than via executing a park loop that you "trap" to.  So icount.pending should remain 0 which means that entering debug mode is not a trap for purposes of icount.

This PR is intended to resolve the forward progress problem and clarify what I think was always the intent.
