### PR TITLE
Dmode is still active for trigger type 15.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -89,8 +89,9 @@
             <value v="15" name="disabled">
             This trigger is disabled. In this state, \RcsrTdataTwo and
             \RcsrTdataThree can be written with any value that is supported for
-            any of the types this trigger implements. The remaining bits in this
-            register are ignored.
+            any of the types this trigger implements.
+            The remaining bits in this register, except for \FcsrTdataOneDmode,
+            are ignored.
             </value>
             
             Other values are reserved for future use.


### PR DESCRIPTION
Previously the spec could be interpreted to mean that dmode is ignored for trigger type 15. Fix this ambiguity and, for consistency, make it so dmode is active for trigger type 15.