### PR TITLE
Clarify stoptime behavior.

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -161,7 +161,7 @@
 
             <value v="1" name="freeze">
             \Rtime is frozen at the time that Debug Mode was entered. When
-            leaving Debug Mode, \Rtime will snap forward to reflect the latest
+            leaving Debug Mode, \Rtime will reflect the latest
             value of \Rmtime again.
 
             While all harts have \FcsrDcsrStoptime=1 and are in Debug Mode,

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -48,6 +48,10 @@
         stepped with both icount and \FcsrDcsrStep then the \FcsrDcsrStep has
         priority.  See table~\ref{tab:priority} for the relative priorities of
         triggers with respect to the ebreak instruction.
+
+        Most multi-hart implementations will probably hardwire \FcsrDcsrStoptime
+        to 0, as the implementation can get complicated and the benefit is
+        small.
         \end{commentary}
 
         <field name="debugver" bits="31:28" access="R" reset="Preset">

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -156,13 +156,16 @@
         </field>
         <field name="stoptime" bits="9" access="WARL" reset="Preset">
             <value v="0" name="normal">
-            Increment \Rtime as usual.
+            \Rtime continues to reflect \Rmtime.
             </value>
 
             <value v="1" name="freeze">
-            Don't increment \Rtime while in Debug Mode.  If all harts
-            have \FcsrDcsrStoptime=1 and are in Debug Mode then \Rmtime
-            is also allowed to stop incrementing.
+            \Rtime is frozen at the time that Debug Mode was entered. When
+            leaving Debug Mode, \Rtime will snap forward to reflect the latest
+            value of \Rmtime again.
+
+            While all harts have \FcsrDcsrStoptime=1 and are in Debug Mode,
+            \Rmtime is allowed to stop incrementing.
             </value>
 
             An implementation may hardwire this bit to 0 or 1.


### PR DESCRIPTION
More accurate state the behavior specified in Section 4.1, so people don't have to read that in order to really understand this part.

See #766.