### PR TITLE
Low bit of dpc is read-only.

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -287,6 +287,10 @@
         \end{tabular}
         \end{table}
 
+        Like \Rmepc, the low bit of \RcsrDpc is read-only zero.  On
+        implementations that support only IALIGN=32, the two low bits are
+        read-only zero.
+
         When resuming, the hart's PC is updated to the virtual address stored in
         \RcsrDpc. A debugger may write \RcsrDpc to change where the hart resumes.
         <field name="dpc" bits="DXLEN-1:0" access="R/W" reset="0" />


### PR DESCRIPTION
Clarification for #778.