### PR TITLE
Clarify JTAG connector section.

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -22,6 +22,9 @@ functionality.
 \section{Terminology}
 
 \begin{description}[style=nextline]
+    \item[advanced feature]
+        An advanced feature for advanced users. Most users will not be able to
+        take advantage of it.
     \item[AMO]
         Atomic Memory Operation.
     \item[BYPASS]
@@ -43,6 +46,8 @@ functionality.
     \item[DXLEN]
         Debug XLEN, which is the widest XLEN a hart supports, ignoring the
         current value of \Fmxl in \Rmisa.
+    \item[essential feature]
+        An essential feature must be present in order for debug to work correctly.
     \item[GPR]
         General Purpose Register.
     \item[hardware platform]
@@ -56,6 +61,9 @@ functionality.
     \item[JTAG]
         Refers to work done by IEEE's Joint Test Action Group, described in
         IEEE 1149.1.
+    \item[legacy feature]
+        A legacy feature should only be implemented to support legacy hardware
+        that is present in a system.
     \item[Minimal RISC-V Debug Specification]
         A subset of the full Debug Specification that allows for very small
         implementations. See Chapter~\ref{chap:dm}.
@@ -67,8 +75,14 @@ functionality.
         Non-Maskable Interrupt.
     \item[physical address]
         An address that is directly usable on the system bus.
+    \item[recommended feature]
+        A recommended feature is not required for debug to work correctly, but
+        it is so useful that it should not be omitted without good reason.
     \item[SBA]
         System Bus Access (see Section \ref{systembusaccess}).
+    \item[specialized feature]
+        A specialized feature, that only makes sense in the context of some
+        specific hardware.
     \item[TAP]
         Test Access Port, defined in IEEE 1149.1.
     \item[TM]

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -161,7 +161,7 @@ is described in Table~\ref{tab:pinout}.
         \hline
         GND & 9 & 10 & nRESET \\
         \hline
-        GND & 11 & 12 & RTCK or NC \\
+        GND & 11 & 12 & RTCK or GND \\
         \hline
         GND & 13 & 14 & nTRST\_PD or NC \\
         \hline
@@ -169,7 +169,7 @@ is described in Table~\ref{tab:pinout}.
         \hline
         GND & 17 & 18 & TRIGIN or NC \\
         \hline
-        GND & 19 & 20 & TRIGOUT or NC \\
+        GND & 19 & 20 & TRIGOUT or GND \\
         \hline
     \end{tabular}
 \end{table}

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -34,7 +34,7 @@ Unimplemented instructions must select the BYPASS register.
 
 \subsection{JTAG Connector}
 
-\subsubsection{JTAG Connector}
+\subsubsection{Recommended JTAG Connector}
 
 To make it easy to acquire debug hardware, this spec recommends a connector
 that is compatible with the MIPI-10 .05 inch connector specification, as described

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -92,7 +92,10 @@ is described in Table~\ref{tab:pinout}.
       \hline
       TDI & JTAG TDI signal, driven by the debug adapter. \\
       \hline
-      nRESET & Active-low reset signal, driven by the debug adapter.
+      nRESET & Open drain active low reset signal, usually driven by the debug
+        adapter.  The signal may be used bi-directional to drive or sense the
+        target reset signal.
+
         Asserting reset should reset any RISC-V cores as well as any other
         peripherals on the PCB. It should not reset the debug logic.  This pin
         is optional but strongly encouraged.

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -131,7 +131,7 @@ the nTRST signal, resulting in a MIPI 10-pin JTAG + nTRST connector.
 \subsubsection{Alternate JTAG Connector}
 
 The MIPI-10 connector should provide plenty of signals for all modern hardware.
-If a design does need more esoteric signals, then the
+If a design does need legacy JTAG signals, then the
 MIPI-20 connector should be used. Its physical connector is virtually identical
 to MIPI-10, except that it's twice as long, supporting twice as many pins. Its
 pinout is shown in Table~\ref{tab:mipitwenty}. The function of each pin

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -10,7 +10,7 @@ through the JTAG data register (DR).
 JTAG refers to IEEE Std 1149.1-2013. It is a standard that defines test logic
 that can be included in an integrated circuit to test the interconnections
 between integrated circuits, test the integrated circuit itself, and observe or
-modify circuit activity during the component’s normal operation.
+modify circuit activity during the component's normal operation.
 This specification uses the latter functionality.
 The JTAG standard defines a Test Access Port (TAP) that
 can be used to read and write a few custom registers, which can be used to
@@ -32,12 +32,13 @@ Unimplemented instructions must select the BYPASS register.
 
 \input{jtag_registers.tex}
 
-\subsection{Recommended JTAG Connector}
+\subsection{JTAG Connector}
+
+\subsubsection{JTAG Connector}
 
 To make it easy to acquire debug hardware, this spec recommends a connector
 that is compatible with the MIPI-10 .05 inch connector specification, as described
-in the MIPI Alliance Recommendation for Debug and Trace Connectors, Version
-1.10.00, 16 March 2011.
+in MIPI Debug \& Trace Connector Recommendations, Version 1.20, 2 July 2021.
 
 The connector has .05 inch spacing, gold-plated male header with .016 inch thick
 hardened copper or beryllium bronze square posts (SAMTEC FTSH or equivalent).
@@ -47,9 +48,9 @@ Viewing the male header from above (the pins pointing at your eye), a target's
 connector looks as it does in Table~\ref{tab:mipiten}.  The function of each pin
 is described in Table~\ref{tab:pinout}.
 
-\begin{table}[htp]
+\begin{table}[H]
     \centering
-    \caption{MIPI-10 Connector Diagram}
+    \caption{MIPI 10-pin JTAG + nRESET Connector Diagram}
     \label{tab:mipiten}
     \begin{tabular}{|r|c|c|l|}
         \hline
@@ -66,15 +67,77 @@ is described in Table~\ref{tab:pinout}.
     \end{tabular}
 \end{table}
 
-If a hardware platform requires nTRST then it is permissible to reuse the nRESET pin as
-the nTRST signal.  If a hardware platform requires both hardware platform reset and TAP reset, the
-MIPI-20 connector should be used. Its physical connector is virtually identical
-to MIPI-10, except that it's twice as long, supporting twice as many pins. Its
-connector is show in Table~\ref{tab:mipitwenty}.
-
 \begin{table}[htp]
     \centering
-    \caption{MIPI-20 Connector Diagram}
+    \caption{JTAG Connector Pin Functions}
+    \label{tab:pinout}
+    \begin{tabulary}{\textwidth}{|c|L|}
+      \hline
+      VREF DEBUG & Reference voltage for logic high. \\
+      \hline
+      GND & Connected to ground. \\
+      \hline
+      TMS & JTAG TMS signal, driven by the debug adapter. \\
+      \hline
+      TCK & JTAG TCK signal, driven by the debug adapter. \\
+      \hline
+      TDO & JTAG TDO signal, driven by the target. \\
+      \hline
+      GND or KEY &
+        This pin may be cut on the male and plugged on the female header to
+        ensure the header is always plugged in correctly. It is, however,
+        recommended to use this pin as an additional ground, to allow for
+        fastest TCK speeds. A shrouded connector should be used to prevent the
+        cable from being plugged in incorrectly. \\
+      \hline
+      TDI & JTAG TDI signal, driven by the debug adapter. \\
+      \hline
+      nRESET & Active-low reset signal, driven by the debug adapter.
+        Asserting reset should reset any RISC-V cores as well as any other
+        peripherals on the PCB. It should not reset the debug logic.  This pin
+        is optional but strongly encouraged.
+
+        If necessary, this pin could be used as nTRST instead.
+
+        nRESET should never be connected to the TAP reset, otherwise the
+        debugger might not be able to debug through a reset to discover the
+        cause of a crash or to maintain execution control after the reset. \\
+      \hline
+      RTCK & Return test clock, driven by the target. A target may relay
+        the TCK signal here once it has processed it, allowing a debugger to
+        adjust its TCK frequency in response. \\
+      \hline
+      nTRST\_PD & Test reset pull-down (optional), driven by the debug
+        adapter. Same function as nTRST, but with pull-down resistor on target.
+        \\
+      \hline
+      nTRST & Test reset (optional), driven by the debug adapter.  Used to
+        reset the JTAG TAP Controller. \\
+      \hline
+      TRIGIN & Not used by this specification, to be driven by debug
+        adapter.  (Can be used for extended functions like UART or boot mode
+        selection by some debug adapters). \\
+      \hline
+      TRIGOUT & Not used by this specification, driven by the target. \\
+      \hline
+    \end{tabulary}
+\end{table}
+
+If a hardware platform requires nTRST then it is permissible to reuse the nRESET pin as
+the nTRST signal, resulting in a MIPI 10-pin JTAG + nTRST connector.
+
+\subsubsection{Alternate JTAG Connector}
+
+The MIPI-10 connector should provide plenty of signals for all modern hardware.
+If a design does need more esoteric signals, then the
+MIPI-20 connector should be used. Its physical connector is virtually identical
+to MIPI-10, except that it's twice as long, supporting twice as many pins. Its
+pinout is shown in Table~\ref{tab:mipitwenty}. The function of each pin
+is described in Table~\ref{tab:pinout}.
+
+\begin{table}[H]
+    \centering
+    \caption{MIPI 20-pin JTAG Connector Diagram}
     \label{tab:mipitwenty}
     \begin{tabular}{|r|c|c|l|}
         \hline
@@ -101,59 +164,31 @@ connector is show in Table~\ref{tab:mipitwenty}.
     \end{tabular}
 \end{table}
 
+\subsection{cJTAG}
+
+This spec does not have specific recommendations on how to use the cJTAG
+protocol.
+
+When implementing cJTAG access to a JTAG DTM, the MIPI 10-pin Narrow JTAG
+connector should be used. Viewing the male header from above (the pins pointing
+at your eye), a target's connector looks as it does in
+Table~\ref{tab:mipicjtag}.
+
 \begin{table}[htp]
     \centering
-    \caption{JTAG Connector Pinout}
-    \label{tab:pinout}
-    \begin{tabulary}{\textwidth}{|r|c|L|}
-      \hline
-      1 & VREF DEBUG & Reference voltage for logic high. \\
-      \hline
-      2 & TMS & JTAG TMS signal, driven by the debug adapter. \\
-      \hline
-      4 & TCK & JTAG TCK signal, driven by the debug adapter. \\
-      \hline
-      6 & TDO & JTAG TDO signal, driven by the target. \\
-      \hline
-      7 & GND or KEY &
-        This pin may be cut on the male and plugged on the female header to
-        ensure the header is always plugged in correctly. It is, however,
-        recommended to use this pin as an additional ground, to allow for
-        fastest TCK speeds. A shrouded connector should be used to prevent the
-        cable from being plugged in incorrectly. \\
-      \hline
-      8 & TDI & JTAG TDI signal, driven by the debug adapter. \\
-      \hline
-      10 & nRESET & Active-low reset signal, driven by the debug adapter.
-        Asserting reset should reset any RISC-V cores as well as any other
-        peripherals on the PCB. It should not reset the debug logic.  This pin
-        is optional but strongly encouraged.
-
-        If necessary, this pin could be used as nTRST instead.
-
-        nRESET should never be connected to the TAP reset, otherwise the
-        debugger might not be able to debug through a reset to discover the
-        cause of a crash or to maintain execution control after the reset. \\
-      \hline
-      12 & RTCK & Return test clock, driven by the target. A target may relay
-        the TCK signal here once it has processed it, allowing a debugger to
-        adjust its TCK frequency in response. \\
-      \hline
-      14 & nTRST\_PD & Test reset pull-down (optional), driven by the debug
-        adapter. Same function as nTRST, but with pull-down resistor on target.
-        \\
-      \hline
-      16 & nTRST & Test reset (optional), driven by the debug adapter.  Used to
-        reset the JTAG TAP Controller. \\
-      \hline
-      18 & TRIGIN & Not used by this specification, to be driven by debug
-        adapter.  (Can be used for extended functions like UART or boot mode
-        selection by some debug adapters). \\
-      \hline
-      20 & TRIGOUT & Not used by this specification, driven by the target. \\
-      \hline
-    \end{tabulary}
+    \caption{MIPI 10-pin Narrow JTAG Connector Diagram}
+    \label{tab:mipicjtag}
+    \begin{tabular}{|r|c|c|l|}
+        \hline
+        VREF DEBUG & 1 & 2 & TMSC \\
+        \hline
+        GND & 3 & 4 & TCKC \\
+        \hline
+        GND & 5 & 6 & EXT \\
+        \hline
+        GND or KEY & 7 & 8 & nTRST\_PD \\
+        \hline
+        GND & 9 & 10 & nRESET \\
+        \hline
+    \end{tabular}
 \end{table}
-
-The same connectors can be used for 2-wire cJTAG. In that case TMS is used for
-TMSC, and TCK is used for TCKC.

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -135,7 +135,10 @@ the nTRST signal, resulting in a MIPI 10-pin JTAG + nTRST connector.
 
 The MIPI-10 connector should provide plenty of signals for all modern hardware.
 If a design does need legacy JTAG signals, then the
-MIPI-20 connector should be used. Its physical connector is virtually identical
+MIPI-20 connector should be used. Pins whose functionality isn't needed may be
+left unconnected.
+
+Its physical connector is virtually identical
 to MIPI-10, except that it's twice as long, supporting twice as many pins. Its
 pinout is shown in Table~\ref{tab:mipitwenty}. The function of each pin
 is described in Table~\ref{tab:pinout}.
@@ -156,15 +159,15 @@ is described in Table~\ref{tab:pinout}.
         \hline
         GND & 9 & 10 & nRESET \\
         \hline
-        GND & 11 & 12 & RTCK \\
+        GND & 11 & 12 & RTCK or NC \\
         \hline
-        GND & 13 & 14 & nTRST\_PD \\
+        GND & 13 & 14 & nTRST\_PD or NC \\
         \hline
-        GND & 15 & 16 & nTRST \\
+        GND & 15 & 16 & nTRST or NC \\
         \hline
-        GND & 17 & 18 & TRIGIN \\
+        GND & 17 & 18 & TRIGIN or NC \\
         \hline
-        GND & 19 & 20 & TRIGOUT \\
+        GND & 19 & 20 & TRIGOUT or NC \\
         \hline
     \end{tabular}
 \end{table}
@@ -175,7 +178,10 @@ This spec does not have specific recommendations on how to use the cJTAG
 protocol.
 
 When implementing cJTAG access to a JTAG DTM, the MIPI 10-pin Narrow JTAG
-connector should be used. Viewing the male header from above (the pins pointing
+connector should be used. Pins whose functionality isn't needed may be left
+unconnected.
+
+Viewing the male header from above (the pins pointing
 at your eye), a target's connector looks as it does in
 Table~\ref{tab:mipicjtag}.
 
@@ -189,9 +195,9 @@ Table~\ref{tab:mipicjtag}.
         \hline
         GND & 3 & 4 & TCKC \\
         \hline
-        GND & 5 & 6 & EXT \\
+        GND & 5 & 6 & EXT or NC \\
         \hline
-        GND or KEY & 7 & 8 & nTRST\_PD \\
+        GND or KEY & 7 & 8 & nTRST\_PD or NC \\
         \hline
         GND & 9 & 10 & nRESET \\
         \hline

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -71,28 +71,21 @@ is described in Table~\ref{tab:pinout}.
     \centering
     \caption{JTAG Connector Pin Functions}
     \label{tab:pinout}
-    \begin{tabulary}{\textwidth}{|c|L|}
+    \begin{tabulary}{\textwidth}{|l|c|L|}
       \hline
-      VREF DEBUG & Reference voltage for logic high. \\
+      Essential & GND & Connected to ground. \\
+      \cline{2-3}
+      & TCK & JTAG TCK signal, driven by the debug adapter. \\
+      \cline{2-3}
+      & TDI & JTAG TDI signal, driven by the debug adapter. \\
+      \cline{2-3}
+      & TDO & JTAG TDO signal, driven by the target. \\
+      \cline{2-3}
+      & TMS & JTAG TMS signal, driven by the debug adapter. \\
+      \cline{2-3}
+      & VREF DEBUG & Reference voltage for logic high. \\
       \hline
-      GND & Connected to ground. \\
-      \hline
-      TMS & JTAG TMS signal, driven by the debug adapter. \\
-      \hline
-      TCK & JTAG TCK signal, driven by the debug adapter. \\
-      \hline
-      TDO & JTAG TDO signal, driven by the target. \\
-      \hline
-      GND or KEY &
-        This pin may be cut on the male and plugged on the female header to
-        ensure the header is always plugged in correctly. It is, however,
-        recommended to use this pin as an additional ground, to allow for
-        fastest TCK speeds. A shrouded connector should be used to prevent the
-        cable from being plugged in incorrectly. \\
-      \hline
-      TDI & JTAG TDI signal, driven by the debug adapter. \\
-      \hline
-      nRESET & Open drain active low reset signal, usually driven by the debug
+      Recommended & nRESET & Open drain active low reset signal, usually driven by the debug
         adapter.  The signal may be used bi-directional to drive or sense the
         target reset signal.
 
@@ -100,32 +93,44 @@ is described in Table~\ref{tab:pinout}.
         peripherals on the PCB. It should not reset the debug logic.  This pin
         is optional but strongly encouraged.
 
-        If necessary, this pin could be used as nTRST instead.
-
         nRESET should never be connected to the TAP reset, otherwise the
         debugger might not be able to debug through a reset to discover the
         cause of a crash or to maintain execution control after the reset. \\
+      \cline{2-3}
+      & KEY &
+        This pin may be cut on the male and plugged on the female header to
+        ensure the header is always plugged in correctly. It is, however,
+        recommended to use this pin as an additional ground, to allow for
+        fastest TCK speeds. A shrouded connector should be used to prevent the
+        cable from being plugged in incorrectly. \\
       \hline
-      RTCK & Return test clock, driven by the target. A target may relay
-        the TCK signal here once it has processed it, allowing a debugger to
-        adjust its TCK frequency in response. \\
+      Advanced & EXT & Reserved for custom use. Could be an input or an output. \\
+      \cline{2-3}
+      & TRIGIN & Not used by this specification, to be driven by debug
+        adapter.  (Can be used for extended functions like UART or boot mode
+        selection by some debug adapters). \\
+      \cline{2-3}
+      & TRIGOUT & Not used by this specification, driven by the target. \\
       \hline
-      nTRST\_PD & Test reset pull-down (optional), driven by the debug
-        adapter. Same function as nTRST, but with pull-down resistor on target.
-        \\
-      \hline
-      nTRST & Test reset (optional), driven by the debug adapter. Asserting
+      Specialized & nTRST & Test reset, driven by the debug adapter. Asserting
         nTRST initializes the JTAG DTM asynchronously. It is used in systems
         where the JTAG DTM is not ready to be used after a normal power up. This
         signal is sometimes called TRST*. \\
       \hline
-      TRIGIN & Not used by this specification, to be driven by debug
-        adapter.  (Can be used for extended functions like UART or boot mode
-        selection by some debug adapters). \\
-      \hline
-      TRIGOUT & Not used by this specification, driven by the target. \\
-      \hline
-      EXT & Reserved for custom use. Could be an input or an output. \\
+      Legacy & RTCK & Return test clock, driven by the target. A target may relay
+        the TCK signal here once it has processed it, allowing a debugger to
+        adjust its TCK frequency in response.
+
+        This signal should only be used to support legacy components that rely
+        on this functionality.
+        \\
+      \cline{2-3}
+      & nTRST\_PD & Test reset pull-down, driven by the debug
+        adapter. Same function as nTRST, but with pull-down resistor on target.
+
+        This signal should only be used to support legacy components that rely
+        on this functionality.
+        \\
       \hline
     \end{tabulary}
 \end{table}
@@ -161,9 +166,9 @@ is described in Table~\ref{tab:pinout}.
         \hline
         GND & 9 & 10 & nRESET \\
         \hline
-        GND & 11 & 12 & RTCK or GND \\
+        GND & 11 & 12 & GND or RTCK \\
         \hline
-        GND & 13 & 14 & nTRST\_PD or NC \\
+        GND & 13 & 14 & NC or nTRST\_PD \\
         \hline
         GND & 15 & 16 & nTRST or NC \\
         \hline
@@ -199,7 +204,7 @@ Table~\ref{tab:mipicjtag}.
         \hline
         GND & 5 & 6 & EXT or NC \\
         \hline
-        GND or KEY & 7 & 8 & nTRST\_PD or NC \\
+        GND or KEY & 7 & 8 & NC or nTRST\_PD \\
         \hline
         GND & 9 & 10 & nRESET \\
         \hline

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -111,8 +111,10 @@ is described in Table~\ref{tab:pinout}.
         adapter. Same function as nTRST, but with pull-down resistor on target.
         \\
       \hline
-      nTRST & Test reset (optional), driven by the debug adapter.  Used to
-        reset the JTAG TAP Controller. \\
+      nTRST & Test reset (optional), driven by the debug adapter. Asserting
+        nTRST initializes the JTAG DTM asynchronously. It is used in systems
+        where the JTAG DTM is not ready to be used after a normal power up. This
+        signal is sometimes called TRST*. \\
       \hline
       TRIGIN & Not used by this specification, to be driven by debug
         adapter.  (Can be used for extended functions like UART or boot mode

--- a/jtagdtm.tex
+++ b/jtagdtm.tex
@@ -125,6 +125,8 @@ is described in Table~\ref{tab:pinout}.
       \hline
       TRIGOUT & Not used by this specification, driven by the target. \\
       \hline
+      EXT & Reserved for custom use. Could be an input or an output. \\
+      \hline
     \end{tabulary}
 \end{table}
 


### PR DESCRIPTION
Make it more clear that MIPI-10 should be sufficient for everyone, mostly by clearly putting MIPI-20 into an alternate connector section.

Expand just a tiny bit on cJTAG.

Update MIPI references to the current version of that document, and mention the pinouts using the same names used there.