### PR TITLE
Exceptions may update PC register in debug mode

### DIFF
--- a/Sdext.tex
+++ b/Sdext.tex
@@ -26,9 +26,9 @@ How Debug Mode is implemented is not specified here.
     Full permission checks, or a relaxed set of permission checks, will apply
     according to \FdmAbstractcsRelaxedpriv.
 \item All interrupts (including NMI) are masked.
-\item Exceptions don't update any registers.  That includes {\tt cause}, {\tt
-    epc}, {\tt tval}, {\tt dpc}, and \Rmstatus. They do end execution of the
-    Program Buffer.
+\item When an exception occurs, {\tt pc} may be updated, while all other registers
+    must not be changed. That includes {\tt cause}, {\tt epc}, {\tt tval}, {\tt dpc},
+    and \Rmstatus. Exceptions do end execution of the Program Buffer.
 \item No action is taken if a trigger matches.
 \item If \FcsrDcsrStopcount is 0 then counters continue. If it is 1 then
     counters are stopped.


### PR DESCRIPTION
A sentence in Section 4.1 Debug Mode is incorrect. 
"Exceptions don’t update any registers."
The ISA registers include PC, GPRs, FPRs, VPRs, and CSRs. Exceptions updates PC to debug trap vector in debug mode. Thus, the sentence should be:
"Exceptions don't update any CSRs."

*Note: exceptions never update GPRs, FPRs, and VPRs regardless of debug mode.