### PR TITLE
Don't imply that matching and firing are the same.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -182,11 +182,11 @@
             M-mode trigger enable field.
 
             <value v="0" name="disabled">
-                Triggers with action=0 do not match/fire while the hart is in M-mode.
+                Triggers with action=0 do not match while the hart is in M-mode.
             </value>
 
             <value v="1" name="enabled">
-                Triggers do match/fire while the hart is in M-mode.
+                Triggers do match while the hart is in M-mode.
             </value>
 
             When a breakpoint trap into M-mode is taken, \FcsrTcontrolMte is set to 0. When {\tt


### PR DESCRIPTION
When reviewing #776, I noticed that this implied that matching and firing are the same.  Just like the other mechanism in section 5.4 prevents matching (rather than firing), I believe that this should prevent matching.

This text was originally added in #309 when tcontrol was added.  I don't think that the match/fire distinction was as crisp back then.
