### PR TITLE
Clarify: non-existent CSR access raises an exception.

### DIFF
--- a/Sdext.tex
+++ b/Sdext.tex
@@ -172,6 +172,9 @@ The supported Core Debug Registers must be implemented for each hart that can
 be debugged. They are CSRs, accessible using the RISC-V {\tt csr} opcodes and
 optionally also using abstract debug commands.
 
+Attempts to access a non-existent Core Debug Register raise an illegal
+instruction exception.
+
 \input{core_registers.tex}
 
 \section{Virtual Debug Registers} \label{virtreg}

--- a/Sdtrig.tex
+++ b/Sdtrig.tex
@@ -12,8 +12,11 @@ a given memory address, or on the address/data in loads/stores.
 
 A hart can be compatible with this specification without implementing any
 trigger functionality at all, but if it is implemented then it must conform to
-this section. If triggers aren't implemented, the CSRs might not exist at all and
-accessing them results in an illegal instruction exception.
+this section.
+Accessing trigger CSRs that are not used by any of the implemented triggers must
+result in an illegal instruction exception. M-Mode and Debug Mode accesses to
+trigger CSRs that are used by any of the implemented triggers must succeed,
+regardless of the current type of the currently selected trigger.
 
 A trigger matches when the conditions that it specifies (e.g. a load from a
 specific address) are met. A trigger fires when a trigger that matches performs
@@ -298,5 +301,8 @@ Code that restores CSR context of triggers that might be configured to fire in
 the current privilege mode must use this same sequence to restore the triggers.
 This avoids the problem of a partially written trigger firing at a different
 time than is expected.
+
+Attempts to access a non-existent Trigger Register raise an illegal instruction
+exception.
 
 \input{hwbp_registers.tex}

--- a/introduction.tex
+++ b/introduction.tex
@@ -169,6 +169,8 @@ incompatible, but unlikely to be noticeable:}
     \item Solutions to deal with reentrancy in Section~\ref{sec:nativetrigger}
         prevent triggers from {\em matching}, not merely {\em firing}. This primarily
         affects \RcsrIcount behavior. \PR{722}
+    \item Attempts to access a non-existent CSR raise an illegal instruction
+        exception. \PR{791}
 \end{steps}
 
 \subsubsection{New Features from 0.13 to 1.0}


### PR DESCRIPTION
The privileged spec already requires this.

This addresses a mailing list discussion subject:Clarification of enumeration procedure in Sdtrig ISA extension