### PR TITLE
Expand mcontrol6.hit into hit0 and hit1, and remove mcontrol6.timing.

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -124,6 +124,10 @@ order to implement 1.0:}
     can be written with any value supported by any of the types this trigger
     supports. \PR{721}
     \item \RcsrTcontrol fields only apply to breakpoint traps, not any trap. \PR{723}
+    \item \FcsrMcontrolSixHitZero (previously called $|hit|$) now contains 0 when a
+        trigger fires more than one instruction after the instruction that
+        matched.  (This information is now reflected in \FcsrMcontrolSixHitOne.)
+        \PR{795}
 \end{steps}
 
 \subsubsection{Minor Changes from 0.13 to 1.0}

--- a/introduction.tex
+++ b/introduction.tex
@@ -124,10 +124,11 @@ order to implement 1.0:}
     can be written with any value supported by any of the types this trigger
     supports. \PR{721}
     \item \RcsrTcontrol fields only apply to breakpoint traps, not any trap. \PR{723}
-    \item \FcsrMcontrolSixHitZero (previously called $|hit|$) now contains 0 when a
+    \item \FcsrMcontrolSixHitZero (previously called \RcsrMcontrolSix.$|hit|$) now contains 0 when a
         trigger fires more than one instruction after the instruction that
         matched.  (This information is now reflected in \FcsrMcontrolSixHitOne.)
         \PR{795}
+    \item \RcsrMcontrolSix.$|timing|$ is now read only 0.
 \end{steps}
 
 \subsubsection{Minor Changes from 0.13 to 1.0}
@@ -155,6 +156,8 @@ incompatible, but unlikely to be noticeable:}
     \item Solutions to deal with reentrancy in Section~\ref{sec:nativetrigger}
         prevent triggers from {\em matching}, not merely {\em firing}. This primarily
         affects \RcsrIcount behavior. \PR{722}
+    \item The timing field in \RcsrMcontrolSix is now tied to 0. It was removed in
+        favor of \FcsrMcontrolSixHitZero and \FcsrMcontrolSixHitOne. \PR{795}
 \end{steps}
 
 \subsubsection{New Features from 0.13 to 1.0}

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -365,8 +365,8 @@
         <field name="timing" bits="18" access="WARL" reset="0">
             <value v="0" name="before">
             The action for this trigger will be taken just before the
-            instruction that triggered it is committed, but after all preceding
-            instructions are committed. \Rxepc or \RcsrDpc (depending
+            instruction that triggered it is retired, but after all preceding
+            instructions are retired. \Rxepc or \RcsrDpc (depending
             on \FcsrMcontrolAction) must be set to the virtual address of the
             instruction that matched.
 
@@ -380,8 +380,8 @@
 
             <value v="1" name="after">
             The action for this trigger will be taken after the instruction
-            that triggered it is committed. It should be taken before the next
-            instruction is committed, but it is better to implement triggers imprecisely
+            that triggered it is retired. It should be taken before the next
+            instruction is retired, but it is better to implement triggers imprecisely
             than to not implement them at all.  \Rxepc or
             \RcsrDpc (depending on \FcsrMcontrolAction) must be set to
             the virtual address of the next instruction that must be executed to
@@ -726,7 +726,7 @@
 
             <value v="1" name="before">
             The trigger fired just before the instruction that triggered it was
-            committed, but after all preceding instructions are committed.
+            retired, but after all preceding instructions are retired.
             \Rxepc or \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set
             to the virtual address of the instruction that matched.
 
@@ -738,7 +738,7 @@
 
             <value v="2" name="after">
             The trigger fired after the instruction that triggered and at least
-            one additional instruction were committed.
+            one additional instruction were retired.
             \Rxepc or \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set
             to the virtual address of the next instruction that must be executed
             to preserve the program flow.
@@ -746,7 +746,7 @@
 
             <value v="3" name="immediately after">
             The trigger fired just after the instruction that triggered it was
-            committed, but before any subsequent instructions were executed.
+            retired, but before any subsequent instructions were executed.
             \Rxepc or \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set
             to the virtual address of the next instruction that must be executed
             to preserve the program flow.

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -696,7 +696,9 @@
 
         <field name="type" bits="XLEN-1:XLEN-4" access="R" reset="6" />
         <field name="dmode" bits="XLEN-5" access="WARL" reset="0" />
-        <field name="0" bits="XLEN-6:25" access="R" reset="0" />
+        <field name="0" bits="XLEN-6:26" access="R" reset="0" />
+        <field name="hit1" bits="25" access="WARL" reset="0">
+        </field>
         <field name="vs" bits="24" access="WARL" reset="0">
             When set, enable this trigger in VS-mode.
             This bit is hard-wired to 0 if the hart does not support
@@ -707,13 +709,45 @@
             This bit is hard-wired to 0 if the hart does not support
             virtualization mode.
         </field>
-        <field name="hit" bits="22" access="WARL" reset="0">
-            If this bit is implemented then it must become set when this
-            trigger fires and may become set when this trigger matches.
-            The trigger's user can set or clear it at any
-            time. It is used to determine which
-            trigger(s) matched.  If the bit is not implemented, it is always 0
-            and writing it has no effect.
+        <field name="hit0" bits="22" access="WARL" reset="0">
+            It they are implemented, \FcsrMcontrolSixHitOne (MSB) and
+            \FcsrMcontrolSixHitZero (LSB) combine into a single 2-bit field that
+            indicates if and when the trigger was hit.
+
+            If either of the bits is not implemented, the unimplemented bits
+            will be wired to 0.
+
+            <value v="0" name="false">
+            The trigger did not fire.
+            </value>
+
+            <value v="1" name="before">
+            The trigger fired just before the instruction that triggered it was
+            committed, but after all preceding instructions are committed.
+            \Rxepc or \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set
+            to the virtual address of the instruction that matched.
+
+            If \FcsrMcontrolSixLoad is set and \FcsrMcontrolSixSelect=1 then a
+            memory access has been performed (including any side effects of
+            performing such an access) even though the load has not updated its
+            destination register.
+            </value>
+
+            <value v="2" name="after">
+            The trigger fired after the instruction that triggered and at least
+            one additional instruction were committed.
+            \Rxepc or \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set
+            to the virtual address of the next instruction that must be executed
+            to preserve the program flow.
+            </value>
+
+            <value v="3" name="immediately after">
+            The trigger fired just after the instruction that triggered it was
+            committed, but before any subsequent instructions were executed.
+            \Rxepc or \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set
+            to the virtual address of the next instruction that must be executed
+            to preserve the program flow.
+            </value>
         </field>
         <field name="select" bits="21" access="WARL" reset="0">
             This bit determines the contents of the XLEN-bit compare values.

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -617,8 +617,13 @@
         the processor core is implemented. To accommodate various
         implementations, execute, load, and store address/data triggers may fire at
         whatever point in time is most convenient for the implementation.
-        The debugger may request specific timings as described in \FcsrMcontrolSixTiming.
         Table~\ref{tab:hwbp_timing} suggests timings for the best user experience.
+        The underlying principle is that firing just before the instruction
+        gives a user more insight, so is preferable. However, depending on the
+        instruction and conditions, it might not be possible to evaluate the
+        trigger until the instruction has partially executed. In that case it is
+        better to let the instruction retire before the trigger fires, to avoid
+        extra memory accesses which might affect the state of the system.
 
         \begin{table}[H]
         \centering
@@ -641,10 +646,8 @@
         \end{tabular}
         \end{table}
 
-        A chain of triggers that don't all have the same \FcsrMcontrolSixTiming
-        value will never fire. That means to implement the suggestions in
-        Table~\ref{tab:hwbp_timing}, both timings should be supported on load
-        address triggers.
+        A chain of triggers must only fire if every trigger in the chain was
+        matched by the same instruction.
 
         This trigger type may be limited to address comparisons (\FcsrMcontrolSixSelect is
         always 0) only. If that is the case and masking is not supported (match
@@ -715,7 +718,7 @@
             indicates if and when the trigger was hit.
 
             If either of the bits is not implemented, the unimplemented bits
-            will be wired to 0.
+            will be read-only 0.
 
             <value v="0" name="false">
             The trigger did not fire.
@@ -727,7 +730,7 @@
             \Rxepc or \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set
             to the virtual address of the instruction that matched.
 
-            If \FcsrMcontrolSixLoad is set and \FcsrMcontrolSixSelect=1 then a
+            If a load operation matched and \FcsrMcontrolSixSelect=1 then a
             memory access has been performed (including any side effects of
             performing such an access) even though the load has not updated its
             destination register.
@@ -767,47 +770,8 @@
             Any bits beyond the size of the data access will contain 0.
             </value>
         </field>
-        <field name="timing" bits="20" access="WARL" reset="0">
-            <value v="0" name="before">
-            The action for this trigger will be taken just before the
-            instruction that triggered it is committed, but after all preceding
-            instructions are committed. \Rxepc or \RcsrDpc (depending
-            on \FcsrMcontrolSixAction) must be set to the virtual address of the
-            instruction that matched.
-
-            If this is combined with \FcsrMcontrolSixLoad and
-            \FcsrMcontrolSixSelect=1 then a memory access will be
-            performed (including any side effects of performing such an access) even
-            though the load will not update its destination register. Debuggers
-            should consider this when setting such breakpoints on, for example,
-            memory-mapped I/O addresses.
-            </value>
-
-            <value v="1" name="after">
-            The action for this trigger will be taken after the instruction
-            that triggered it is committed. It should be taken before the next
-            instruction is committed, but it is better to implement triggers imprecisely
-            than to not implement them at all.  \Rxepc or
-            \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set to
-            the virtual address of the next instruction that must be executed to
-            preserve the program flow.
-            </value>
-
-            Most hardware will only implement one timing or the other, possibly
-            dependent on \FcsrMcontrolSixSelect, \FcsrMcontrolSixExecute,
-            \FcsrMcontrolSixLoad, and \FcsrMcontrolSixStore. This bit
-            primarily exists for the hardware to communicate to the debugger
-            what will happen. Hardware may implement the bit fully writable, in
-            which case the debugger has a little more control.
-
-            Data load triggers with \FcsrMcontrolSixTiming of 0 will result in the same load
-            happening again when the debugger lets the hart run. For data load
-            triggers, debuggers must first attempt to set the breakpoint with
-            \FcsrMcontrolSixTiming of 1.
-
-            If a trigger with \FcsrMcontrolSixTiming of 0 matches, it is
-            implementation-dependent whether that prevents a trigger with
-            \FcsrMcontrolSixTiming of 1 matching as well.
+        <field name="0" bits="20" access="WARL" reset="0">
+            This used to be used for timing, but is currently read only 0.
         </field>
         <field name="size" bits="19:16" access="WARL" reset="0">
             <value v="0" name="any">


### PR DESCRIPTION
This lets an implementation be more specific about when a trigger fired in relation to the instruction that matched, to avoid user confusion when triggers fire late.

It also simplifies the spec around desired trigger timing behavior, simply asking for best effort to match the recommendation from the table.