### PR TITLE
Debuggers should accept mcontrol6.20 reading back 1.

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -170,8 +170,6 @@ incompatible, but unlikely to be noticeable:}
     \item Solutions to deal with reentrancy in Section~\ref{sec:nativetrigger}
         prevent triggers from {\em matching}, not merely {\em firing}. This primarily
         affects \RcsrIcount behavior. \PR{722}
-    \item The timing field in \RcsrMcontrolSix is now tied to 0. It was removed in
-        favor of \FcsrMcontrolSixHitZero and \FcsrMcontrolSixHitOne. \PR{795}
 \end{steps}
 
 \subsubsection{New Features from 0.13 to 1.0}

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -772,6 +772,10 @@
         </field>
         <field name="0" bits="20" access="WARL" reset="0">
             This used to be used for timing, but is currently read only 0.
+
+            Debuggers should accept this bit reading back 1 when trying to set a
+            trigger. It indicates the target implemented an older version of the
+            spec. The trigger will still be hit.
         </field>
         <field name="size" bits="19:16" access="WARL" reset="0">
             <value v="0" name="any">


### PR DESCRIPTION
This bit used to be used to request/acknowledge trigger timing information. This change ensures triggers that implements the spec before #795 will still work.