### PR TITLE
Document behavior for abstract dpc access while running.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -471,18 +471,6 @@ Mode, and \FdmAbstractcsCmderr is set to 3 ({\tt exception error}).  If the debu
 executes a program that doesn't terminate with an {\tt ebreak} instruction, the
 hart will remain in Debug Mode and the debugger will lose control of the hart.
 
-Executing the Program Buffer may cause the value of \RcsrDpc to become \unspecified. If that is the case, it must be
-possible to read/write \RcsrDpc using an abstract command with \FacAccessregisterPostexec not set.
-The debugger must attempt to save \RcsrDpc between halting and
-executing a Program Buffer, and then restore \RcsrDpc before leaving Debug Mode.
-
-\begin{commentary}
-    Allowing \RcsrDpc to become \unspecified\ upon Program Buffer execution
-    allows for direct
-    implementations that don't have a separate PC register, and do need to use
-    the PC when executing the Program Buffer.
-\end{commentary}
-
 The Program Buffer may be implemented as RAM which is accessible to the
 hart. A debugger can determine if this is the case by executing small
 programs that attempt to write and read back relative to \Rpc while executing

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -288,6 +288,20 @@
         \end{tabular}
         \end{table}
 
+        Executing the Program Buffer may cause the value of \RcsrDpc to become
+        \unspecified. If that is the case, it must be possible to read/write
+        \RcsrDpc using an abstract command with \FacAccessregisterPostexec not
+        set.  The debugger must attempt to save \RcsrDpc between halting and
+        executing a Program Buffer, and then restore \RcsrDpc before leaving
+        Debug Mode.
+
+        \begin{commentary}
+            Allowing \RcsrDpc to become \unspecified\ upon Program Buffer
+            execution allows for direct implementations that don't have a
+            separate PC register, and do need to use the PC when executing the
+            Program Buffer.
+        \end{commentary}
+
         The writability of \RcsrDpc follows the same rules as \Rmepc as defined
         in the Privileged Spec.  In particular, \RcsrDpc must be able to hold
         all valid virtual addresses and the writability of the low bits depends

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -302,6 +302,14 @@
             Program Buffer.
         \end{commentary}
 
+        If the Access Register abstract command supports reading \RcsrDpc while
+        the hart is running, then the value read should be the address of a
+        recently executed instruction.
+
+        If the Access Register abstract command supports writing \RcsrDpc while
+        the hart is running, then the executing program should jump to the
+        written address shortly after the write occurs.
+
         The writability of \RcsrDpc follows the same rules as \Rmepc as defined
         in the Privileged Spec.  In particular, \RcsrDpc must be able to hold
         all valid virtual addresses and the writability of the low bits depends


### PR DESCRIPTION
Addresses https://github.com/riscv/riscv-debug-spec/issues/824.