### PR TITLE
icount: Remove confusing statement about inhibited trigger.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -1000,8 +1000,7 @@
         execution, the trigger still only matches once for that instruction.
 
         When \FcsrIcountCount is greater than 1 and the trigger matches, then
-        \FcsrIcountCount is decremented by 1. (This is true even if the action configured in
-        the trigger is inhibited for some reason.)
+        \FcsrIcountCount is decremented by 1.
 
         When \FcsrIcountCount is 1 and the trigger matches, then \FcsrIcountPending
         becomes set. In addition \FcsrIcountCount will become 0 unless it is


### PR DESCRIPTION
"Inhibited" is not well-defined, and this language is no longer necessary. It was added when the original sentence said:
> When \FcsrIcountCount is greater than 1, every instruction completed or
> trap taken from a mode where the trigger is enabled decrements
> \FcsrIcountCount by 1.

Now there is no more reference to a mode, so the clarification isn't needed either.

Addresses #813