### PR TITLE
Clarify that stepie applies to dcsr.step but not icount.

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -130,12 +130,14 @@
         </field>
         <field name="stepie" bits="11" access="WARL" reset="0">
             <value v="0" name="interrupts disabled">
-            Interrupts (including NMI) are disabled during single stepping.
+            Interrupts (including NMI) are disabled during single stepping
+            with \FcsrDcsrStep set.
             This value should be supported.
             </value>
 
             <value v="1" name="interrupts enabled">
-            Interrupts (including NMI) are enabled during single stepping.
+            Interrupts (including NMI) are enabled during single stepping
+            with \FcsrDcsrStep set.
             </value>
 
             Implementations may hard wire this bit to 0.


### PR DESCRIPTION
A coworker assumed this morning that stepie affected single stepping with icount (which is not preferred but is allowed).  The spec wasn't clear one way or the other but I assume that this is the intent.
