### PR TITLE
Debug interaction with wrs.sto/wrs.nto

### DIFF
--- a/Sdext.tex
+++ b/Sdext.tex
@@ -91,6 +91,12 @@ If halt is requested while {\tt wfi} is executing, then the hart must leave the
 stalled state, completing this instruction's execution, and then enter Debug
 Mode.
 
+\section{Wait-on-Reservation-Set Instructions}
+
+If halt is requested while {\tt wrs.sto} or {\tt wrs.nto} is executing, then the
+hart must leave the stalled state, completing this instruction's execution, and
+then enter Debug Mode.
+
 \section{Single Step}
 
 \subsection{Step Bit In Dcsr} \label{stepBit}

--- a/Sdext.tex
+++ b/Sdext.tex
@@ -36,7 +36,7 @@ How Debug Mode is implemented is not specified here.
 \item If \FcsrDcsrStoptime is 0 then \Rtime continues to update. If
     it is 1 then \Rtime will not update. It will resynchronize with
     \Rmtime after leaving Debug Mode.
-\item The {\tt wfi} instruction acts as a {\tt nop}.
+\item The {\tt wfi}, {\tt wrs.sto}, {\tt wrs.nto} instructions act as a {\tt nop}.
 \item Almost all instructions that change the privilege mode have \unspecified\
     behavior.  This includes {\tt ecall}, {\tt mret}, {\tt sret}, and {\tt uret}.
     (To change the privilege mode, the debugger can write

--- a/Sdext.tex
+++ b/Sdext.tex
@@ -125,8 +125,9 @@ an instruction fetch causes an exception, that exception does not occur until
 the next time the hart is resumed. Similarly, a trigger at the new address does
 not fire until the hart actually attempts to execute that instruction.
 
-If the instruction being stepped over is {\tt wfi} and would normally stall the
-hart, then instead the instruction is treated as {\tt nop}.
+If the instruction being stepped over is {\tt wfi}, {\tt wrs.sto}, or {\tt wrs.nto}
+and would normally stall the hart, then instead the instruction is treated as
+{\tt nop}.
 
 \subsection{Icount Trigger}
 


### PR DESCRIPTION
The `wrs.sto` and `wrs.nto` instructions follow the behavior of `wfi` for interaction with debug.
- Are `nop` in debug mode
- Are `nop` when stepped over
- Leave stalled stated on a halt request