### PR TITLE
Reentrant trigger prevention inhibits match *or fire*

### DIFF
--- a/Sdtrig.tex
+++ b/Sdtrig.tex
@@ -213,11 +213,11 @@ at any time.
 should implement one of the following two solutions to solve the problem of
 reentrancy:}
 \item The hardware prevents triggers with \FcsrMcontrolSixAction=0 from
-matching while in M-mode and while \FcsrMstatusMie in \Rmstatus is 0.  If
+matching or firing while in M-mode and while \FcsrMstatusMie in \Rmstatus is 0.  If
 \Rmedeleg[3]=1 then it prevents triggers with \FcsrMcontrolSixAction=0
-from matching while in S-mode and while \FcsrSstatusSie in \Rsstatus is 0.
+from matching or firing while in S-mode and while \FcsrSstatusSie in \Rsstatus is 0.
 If \Rmedeleg[3]=1 and \Rhedeleg[3]=1 then it prevents triggers with
-\FcsrMcontrolSixAction=0 from matching while in VS-mode and while
+\FcsrMcontrolSixAction=0 from matching or firing while in VS-mode and while
 \FcsrSstatusSie in \Rvsstatus is 0.
 \item \FcsrTcontrolMte and \FcsrTcontrolMpte in \RcsrTcontrol is
 implemented.  \Rmedeleg[3] is hard-wired to 0.


### PR DESCRIPTION
This is a substantive change, but a bugfix, so OK to merge.

Addresses #812.