### PR TITLE
Clarify that icount decrements on interrupt traps.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -994,6 +994,7 @@
                 mode where the trigger is enabled.
                 This explicitly includes {\em x}\/RET instructions.
             \item A trap is taken from a privilege mode where the trigger is enabled.
+                This explicitly includes traps taken due to interrupts.
         \end{steps}
 
         If more than one of the above events occur during a single instruction


### PR DESCRIPTION
The rationale is that if icount is enabled in the current mode and the mode of the trap handler, when you single step you don't want to step past the first instruction of the trap handler, which you didn't know was going to be executed. Having to step multiple times to get past an interrupt to actually execute the instruction you tended to step is addressed the same way as already documented in the appendix.
    
Addresses a question from #842.