### PR TITLE
Add support for Zicfilp and the hart ELP state

### DIFF
--- a/Sdext.tex
+++ b/Sdext.tex
@@ -61,6 +61,9 @@ How Debug Mode is implemented is not specified here.
     illegal instructions.
 \item Instructions that depend on the value of the PC (e.g.\ {\tt auipc}) may act
     as illegal instructions.
+\item The ELP state is {\tt NO\_LP\_EXPECTED} and is not updated by any
+    instructions. {\tt lpad} executes as a no-op. (To change the ELP state, the
+    debugger can write \FcsrDcsrElp in \RcsrDcsr).
 \item Effective XLEN is DXLEN.
 \item Forward progress is guaranteed.
 \end{steps}
@@ -170,6 +173,7 @@ executed.
 \begin{steps}{When a hart halts:}
     \item \FcsrDcsrCause is updated.
     \item \FcsrDcsrPrv and \FcsrDcsrV are set to reflect current privilege mode.
+    \item \FcsrDcsrElp is set to the current ELP state.
     \item \RcsrDpc is set to the next instruction that should be executed.
     \item If the current instruction can be partially executed and should be
         restarted to complete, then the relevant state for that is updated. E.g.
@@ -186,6 +190,8 @@ executed.
     \item \Rpc changes to the value stored in \RcsrDpc.
     \item The current privilege mode and virtualization mode are changed to that specified by
         \FcsrDcsrPrv and \FcsrDcsrV.
+    \item The current ELP state is changed to that specified by \FcsrDcsrElp, or to {\tt NO\_LP\_EXPECTED}
+        if forward CFI is not enabled at the new privilege mode.
     \item If the new privilege mode is less privileged than M-mode,
         \FcsrMstatusMprv in \Rmstatus is cleared.
     \item The hart is no longer in debug mode.

--- a/implementations.tex
+++ b/implementations.tex
@@ -67,7 +67,7 @@ To resume execution, the debug module sets a flag which causes the hart to execu
 not executing from the Program Buffer.
 Its recommended encoding is 0x7b200073.
 When {\tt dret} is executed, \Rpc is restored from \RcsrDpc and normal execution resumes at the
-privilege set by \FcsrDcsrPrv and \FcsrDcsrV.
+privilege set by \FcsrDcsrPrv and \FcsrDcsrV and the ELP state set by \FcsrDcsrElp.
 
 \RdmDataZero etc. are mapped into regular memory at an address relative to \Rzero
 with only a 12-bit {\tt imm}. The exact address is an implementation

--- a/introduction.tex
+++ b/introduction.tex
@@ -46,6 +46,8 @@ functionality.
     \item[DXLEN]
         Debug XLEN, which is the widest XLEN a hart supports, ignoring the
         current value of \Fmxl in \Rmisa.
+    \item[ELP state]
+        Expected landing pad state, defined by the Zicfilp extension.
     \item[essential feature]
         An essential feature must be present in order for debug to work correctly.
     \item[GPR]

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -3,7 +3,8 @@
 
     <register name="Debug Control and Status" short="dcsr" address="0x7b0">
         Upon entry into Debug Mode, \FcsrDcsrV and \FcsrDcsrPrv are updated
-        with the privilege level the hart was previously in, and \FcsrDcsrCause
+        with the privilege level the hart was previously in, \FcsrDcsrElp is
+        updated with the ELP state the hart was previously in, and \FcsrDcsrCause
         is updated with the reason for Debug Mode entry.  Other than these
         fields and \FcsrDcsrNmip, the other fields of \RcsrDcsr are only
         writable by the external debugger.
@@ -69,7 +70,17 @@
             available version of this spec.
             </value>
         </field>
-        <field name="0" bits="27:18" access="R" reset="0" />
+	<field name="0" bits="27:19" access="R" reset="0" />
+        <field name="elp" bits="18" access="WARL" reset="0">
+            Contains the ELP state of the hart, as defined in the Zicfilp
+            specification, when Debug Mode was entered.
+            The encoding is described in Table \ref{tab:elpmode}.
+            A debugger can change this value to change the hart's ELP state
+            when exiting Debug Mode.
+            The value will be ignored on exit if forward CFI is not enabled at
+            the privilege mode specified by \FcsrDcsrPrv.
+            This bit is hardwired to 0 on harts that do not support Zicfilp.
+        </field>
         <field name="ebreakvs" bits="17" access="WARL" reset="0">
             <value v="0" name="exception">
             {\tt ebreak} instructions in VS-mode behave as described in the

--- a/xml/sw_registers.xml
+++ b/xml/sw_registers.xml
@@ -12,8 +12,9 @@
         Users can write this register to change the privilege mode that
         the hart will run in when it resumes.
 
-        This register contains \FcsrDcsrPrv and \FcsrDcsrV from \RcsrDcsr, but in a place that the user
-        is expected to access. The user should not access \RcsrDcsr directly,
+        This register contains \FcsrDcsrPrv, \FcsrDcsrV, and \FcsrDcsrElp from
+        \RcsrDcsr, but in a place that the user is expected to access.
+        The user should not access \RcsrDcsr directly,
         because doing so might interfere with the debugger.
 
         \begin{table}
@@ -38,6 +39,28 @@
         \end{tabular}
         \end{table}
 
+        \begin{table}
+        \centering
+        \caption{Expected Landing Pad Encoding}
+        \label{tab:elpmode}
+        \begin{tabular}{|c|l|}
+        \hline
+        elp &amp; Name \\
+        \hline
+        0 &amp; {\tt NO\_LP\_EXPECTED} \\
+        \hline
+        1 &amp; {\tt LP\_EXPECTED} \\
+        \hline
+        \end{tabular}
+        \end{table}
+
+        <field name="elp" bits="3" access="WARL" reset="0">
+          Contains the ELP state the hart was operating in when Debug
+          Mode was entered. The encoding is described in Table \ref{tab:elpmode},
+          and matches the expected landing pad encoding in the Zicfilp specification.
+          A user can write this value to change the hart's ELP state
+          when exiting Debug Mode.
+        </field>
         <field name="v" bits="2" access="WARL" reset="0">
           Contains the virtualization mode the hart was operating in when Debug
           Mode was entered. The encoding is described in Table \ref{tab:privmode},


### PR DESCRIPTION
[Zicfilp](https://github.com/riscv/riscv-cfi/blob/main/cfi_forward.adoc) adds a new ELP state to each hart, which is handled like the privilege mode: it affects all instructions, is not visible in any CSR, but is saved into CSR fields by traps and restored by trap returns.

Add it to the debug spec in the same fashion as the privilege mode, and specify that it does not affect execution in Debug Mode.

(Draft because Zicfilp is not frozen.)