### PR TITLE
AR: Use manager/subordinate for master/slave.

### DIFF
--- a/debug_module.tex
+++ b/debug_module.tex
@@ -43,9 +43,9 @@ A single DM can debug up to $2^{20}$ harts.
 
 \section{Debug Module Interface (DMI)} \label{dmi}
 
-Debug Modules are subordinate devices on a bus called the Debug Module Interface (DMI). The
-coordinator of the bus is the Debug Transport Module(s).
-The Debug Module Interface can be a trivial bus with one coordinator and one subordinate device (see \ref{dmi_signals}),
+Debug Modules are subordinates on a bus called the Debug Module Interface (DMI). The
+bus manager is the Debug Transport Module(s).
+The Debug Module Interface can be a trivial bus with one manager and one subordinate (see \ref{dmi_signals}),
 or use a more full-featured bus like TileLink or the AMBA Advanced Peripheral
 Bus. The details are left to the system designer.
 

--- a/future.tex
+++ b/future.tex
@@ -9,8 +9,8 @@ Some future version of this spec may implement some of the following features.
    \item The spec defines several additions to the Device Tree which enable a
       debugger to discover hart IDs and supported triggers for all the harts
       in the system.
-   \item DTMs can function as general bus subordinate devices, so they would look like
-      regular RAM to bus coordinators.
+   \item DTMs can function as general bus subordinates, so they would look like
+      regular RAM to bus managers.
    \item Harts can be divided into groups. All the harts in the same group can
       be halted/run/stepped simultaneously. When a hart hits a breakpoint, all
       the other harts in the same group also halt within a few clock cycles.

--- a/introduction.tex
+++ b/introduction.tex
@@ -354,7 +354,7 @@ The debug interface described in this specification supports the following featu
    \item Registers can be accessed without halting. (Optional)
    \item A running hart can be directed to execute a short sequence
        of instructions, with little overhead. (Optional)
-   \item A system bus coordinator allows memory access without
+   \item A system bus manager allows memory access without
        involving any hart. (Optional)
    \item A RISC-V hart can be halted when a trigger matches the PC,
        read/write address/data, or an instruction opcode. (Optional)

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -879,7 +879,7 @@
             initiated by the Debug Module.
         </field>
         <field name="sbbusy" bits="21" access="R" reset="0">
-            When 1, indicates the system bus coordinator is busy. (Whether the
+            When 1, indicates the system bus manager is busy. (Whether the
             system bus itself is busy is related, but not the same thing.) This
             bit goes high immediately when a read or write is requested for any
             reason, and does not go low until the access is fully completed.
@@ -928,7 +928,7 @@
         </field>
         <field name="sberror" bits="14:12" access="R/W1C" reset="0">
             When the Debug Module's system bus
-            coordinator encounters an error, this field gets set. The bits in this
+            manager encounters an error, this field gets set. The bits in this
             field remain set until they are cleared by writing 1 to them.
             While this field is non-zero, no more system bus accesses can be
             initiated by the Debug Module.
@@ -983,7 +983,7 @@
     <register name="System Bus Address 31:0" short="sbaddress0" address="0x39">
         If \FdmSbcsSbasize is 0, then this register is not present.
 
-        When the system bus coordinator is busy, writes to this register will set
+        When the system bus manager is busy, writes to this register will set
         \FdmSbcsSbbusyerror and don't do anything else.
 
         \begin{steps}{If \FdmSbcsSberror is 0, \FdmSbcsSbbusyerror is 0, and \FdmSbcsSbreadonaddr
@@ -1003,7 +1003,7 @@
     <register name="System Bus Address 63:32" short="sbaddress1" address="0x3a">
         If \FdmSbcsSbasize is less than 33, then this register is not present.
 
-        When the system bus coordinator is busy, writes to this register will set
+        When the system bus manager is busy, writes to this register will set
         \FdmSbcsSbbusyerror and don't do anything else.
 
         <field name="address" bits="31:0" access="R/W" reset="0">
@@ -1015,7 +1015,7 @@
     <register name="System Bus Address 95:64" short="sbaddress2" address="0x3b">
         If \FdmSbcsSbasize is less than 65, then this register is not present.
 
-        When the system bus coordinator is busy, writes to this register will set
+        When the system bus manager is busy, writes to this register will set
         \FdmSbcsSbbusyerror and don't do anything else.
 
         <field name="address" bits="31:0" access="R/W" reset="0">
@@ -1027,7 +1027,7 @@
     <register name="System Bus Address 127:96" short="sbaddress3" address="0x37">
         If \FdmSbcsSbasize is less than 97, then this register is not present.
 
-        When the system bus coordinator is busy, writes to this register will set
+        When the system bus manager is busy, writes to this register will set
         \FdmSbcsSbbusyerror and don't do anything else.
 
         <field name="address" bits="31:0" access="R/W" reset="0">
@@ -1046,7 +1046,7 @@
 
         If either \FdmSbcsSberror or \FdmSbcsSbbusyerror isn't 0 then accesses do nothing.
 
-        If the bus coordinator is busy then accesses set \FdmSbcsSbbusyerror, and don't do
+        If the bus manager is busy then accesses set \FdmSbcsSbbusyerror, and don't do
         anything else.
 
         \begin{steps}{Writes to this register start the following:}
@@ -1083,7 +1083,7 @@
         If \FdmSbcsSbaccessSixtyfour and \FdmSbcsSbaccessOneTwentyeight are 0, then this
         register is not present.
 
-        If the bus coordinator is busy then accesses set \FdmSbcsSbbusyerror, and don't do
+        If the bus manager is busy then accesses set \FdmSbcsSbbusyerror, and don't do
         anything else.
 
         <field name="data" bits="31:0" access="R/W" reset="0">
@@ -1095,7 +1095,7 @@
     <register name="System Bus Data 95:64" short="sbdata2" address="0x3e">
         This register only exists if \FdmSbcsSbaccessOneTwentyeight is 1.
 
-        If the bus coordinator is busy then accesses set \FdmSbcsSbbusyerror, and don't do
+        If the bus manager is busy then accesses set \FdmSbcsSbbusyerror, and don't do
         anything else.
 
         <field name="data" bits="31:0" access="R/W" reset="0">
@@ -1107,7 +1107,7 @@
     <register name="System Bus Data 127:96" short="sbdata3" address="0x3f">
         This register only exists if \FdmSbcsSbaccessOneTwentyeight is 1.
 
-        If the bus coordinator is busy then accesses set \FdmSbcsSbbusyerror, and don't do
+        If the bus manager is busy then accesses set \FdmSbcsSbbusyerror, and don't do
         anything else.
 
         <field name="data" bits="31:0" access="R/W" reset="0">

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -42,11 +42,11 @@
             </value>
 
             <value v="2" name="communication error">
-                There was an error between the DMI and a DMI subordinate device.
+                There was an error between the DMI and a DMI subordinate.
             </value>
 
             <value v="3" name="device error">
-                The DMI subordinate device reported an error, e.g. because a
+                The DMI subordinate reported an error, e.g. because a
                 non-existent register was accessed.
             </value>
 


### PR DESCRIPTION
Address AR feedback:
> Master/slave terminology is obviously being replaced across RV specs -
> in a somewhat haphazard manner as far as what is being used for
> replacements.  The ARC suggests using the following (and will be
> proposing this to be the standard replacement across RV specs):
> Manager/subordinate  (which remains intuitive and happens to maintain
> the M/S starting letters fwiw)