### PR TITLE
Recommend debug ROM is not cached.

### DIFF
--- a/implementations.tex
+++ b/implementations.tex
@@ -30,6 +30,8 @@ When the halt request bit is set, the Debug Module raises a special interrupt
 to the selected harts. This interrupt causes each
 hart to enter Debug Mode and jump to a defined
 memory region that is serviced by the DM and is only accessible to the harts in Debug Mode.
+Accesses to this memory should be uncached to avoid side effects from
+debugging operations.
 When taking this jump, \Rpc is saved to \RcsrDpc and \FcsrDcsrCause is updated
 in \RcsrDcsr.  This jump is similar to a trap but it is not architecturally
 considered a trap, so for instance doesn't count as a trap for trigger behavior.


### PR DESCRIPTION
The performance of this code doesn't matter (compared to how slow JTAG is), and the fewer side effects debugging has, the better.