### PR TITLE
AR: Don't use "non-existent" in reference to register.

### DIFF
--- a/Sdext.tex
+++ b/Sdext.tex
@@ -203,7 +203,7 @@ The supported Core Debug Registers must be implemented for each hart that can
 be debugged. They are CSRs, accessible using the RISC-V {\tt csr} opcodes and
 optionally also using abstract debug commands.
 
-Attempts to access a non-existent Core Debug Register raise an illegal
+Attempts to access an unimplemented Core Debug Register raise an illegal
 instruction exception.
 
 \input{core_registers.tex}

--- a/Sdtrig.tex
+++ b/Sdtrig.tex
@@ -357,7 +357,7 @@ the current privilege mode must use this same sequence to restore the triggers.
 This avoids the problem of a partially written trigger firing at a different
 time than is expected.
 
-Attempts to access a non-existent Trigger Register raise an illegal instruction
+Attempts to access an unimplemented Trigger Register raise an illegal instruction
 exception.
 
 \input{hwbp_registers.tex}

--- a/debug_module.tex
+++ b/debug_module.tex
@@ -643,7 +643,7 @@ The registers described in this section are accessed over the DMI bus.  Each DM
 has a base address (which is 0 for the first DM). The register addresses below
 are offsets from this base address.
 
-When read, unimplemented or non-existent Debug Module DMI Registers return 0.
-Writing them has no effect.
+Debug Module DMI Registers that are unimplemented or not mentioned in the table
+below return 0 when read. Writing them has no effect.
 
 \input{dm_registers.tex}

--- a/introduction.tex
+++ b/introduction.tex
@@ -174,7 +174,7 @@ incompatible, but unlikely to be noticeable:}
     \item Solutions to deal with reentrancy in Section~\ref{sec:nativetrigger}
         prevent triggers from {\em matching}, not merely {\em firing}. This primarily
         affects \RcsrIcount behavior. \PR{722}
-    \item Attempts to access a non-existent CSR raise an illegal instruction
+    \item Attempts to access an unimplemented CSR raise an illegal instruction
         exception. \PR{791}
 \end{steps}
 

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -46,8 +46,7 @@
             </value>
 
             <value v="3" name="device error">
-                The DMI subordinate reported an error, e.g. because a
-                non-existent register was accessed.
+                The DMI subordinate reported an error.
             </value>
 
             <value v="4" name="unknown">


### PR DESCRIPTION
We can always be more clear using other terminology.