### PR TITLE
AR: Comment on unimplemented CSR behavior.

### DIFF
--- a/Sdtrig.tex
+++ b/Sdtrig.tex
@@ -358,4 +358,12 @@ time than is expected.
 Attempts to access an unimplemented Trigger Register raise an illegal instruction
 exception.
 
+\begin{commentary}
+    Privileged spec v1.12 requires accesses to unimplemented CSRs to raise
+    illegal instruction exceptions, but that may change in the future. Even if
+    it does change, the behavior here overrides it for Sdtrig CSRs for backwards
+    compatibility. This is even true if Sdtrig is not implemented at all, so the
+    discovery algorithm in Section~\ref{sec:trigger} still works.
+\end{commentary}
+
 \input{hwbp_registers.tex}


### PR DESCRIPTION
    After a very long e-mail discussion, we landed on maintaining
    unimplemented CSR behavior as-is. Just add a quick note to be explicit
    about that intention. The end of the discussion is basically:
    1. If Sdtrig CSRs are accessed when they are not implemented or Sdtrig
       is not implemented, the hart will trap. This is to maintain backwards
       compatibility with existing implementations that use this for
       discovery.
    2. If Sdext CSRs are accessed when they are not implemented, the hart
       will trap. (No need to specify behavior when Sdext is not
       implemented, because in that case Debug Mode doesn't exist and the
       CSRs aren't accessible anyway.) This is to be consistent with Sdtrig
       behavior.
