### PR TITLE
Sdtrig must implement at least one trigger.

### DIFF
--- a/Sdtrig.tex
+++ b/Sdtrig.tex
@@ -10,9 +10,7 @@ without having to execute a special instruction. This makes them invaluable
 when debugging code from ROM. They can trigger on execution of instructions at
 a given memory address, or on the address/data in loads/stores.
 
-A hart can be compatible with this specification without implementing any
-trigger functionality at all, but if it is implemented then it must conform to
-this section.
+If Sdtrig is implemented, the Trigger Module must support at least one trigger.
 Accessing trigger CSRs that are not used by any of the implemented triggers must
 result in an illegal instruction exception. M-Mode and Debug Mode accesses to
 trigger CSRs that are used by any of the implemented triggers must succeed,


### PR DESCRIPTION
Based on discussion in #870, where Paul mentioned:
> I don't think that it's incompatible. Old implementations would have
> said that they do the debug spec but there was no "Sdtrig" until
> recently. I guess that somebody in the last year or so could have
> claimed Sdtrig compliance without any triggers but that seems unlikely
> and I don't think that adding this new requirement would require them to
> change anything other than some Powerpoint slides.