### PR TITLE
AR: Remove comment about privspec/CSR behavior

### DIFF
--- a/Sdtrig.tex
+++ b/Sdtrig.tex
@@ -358,12 +358,4 @@ time than is expected.
 Attempts to access an unimplemented Trigger Register raise an illegal instruction
 exception.
 
-\begin{commentary}
-    Privileged spec v1.12 requires accesses to unimplemented CSRs to raise
-    illegal instruction exceptions, but that may change in the future. Even if
-    it does change, the behavior here overrides it for Sdtrig CSRs for backwards
-    compatibility. This is even true if Sdtrig is not implemented at all, so the
-    discovery algorithm in Section~\ref{sec:trigger} still works.
-\end{commentary}
-
 \input{hwbp_registers.tex}


### PR DESCRIPTION
From Greg: "... why is this non-normative comment even necessary?  It's directly consistent with 1.12, and it's compatible with 1.13 which allows for trapping and just doesn't require it.  In other words, wrt 1.13, this trapping mandate by Debug 1.0 doesn't conflict with Priv 1.13.  And that allows Debug 1.0 to come along and tighten what is allowed by 1.13."