### PR TITLE
AR: Clarify unimplemented Sdtrig.

### DIFF
--- a/Sdext.tex
+++ b/Sdext.tex
@@ -12,6 +12,9 @@ In order to be compatible with this specification an implementation must
 implement everything described in this section that is not explicitly listed as
 optional.
 
+If Sdext is implemented and Sdtrig is not implemented, then accessing any of the
+Sdtrig CSRs must raise an illegal instruction exception.
+
 \section{Debug Mode} \label{debugmode}
 
 Debug Mode is a special processor mode used only when a hart is halted for


### PR DESCRIPTION
If Sdext is implemented and Sdtrig is not implemented, then accessing any of the Sdtrig CSRs must raise an illegal instruction exception.

(This is already said in privspec 1.12, but that might change in the future.)