### PR TITLE
AR: tcontrol.mie applies to all traps, not just breakpoints

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -222,6 +222,8 @@ value that they wrote, and must not assume that the result of the last abstract
 command is available as argument to the next abstract command. \PR{728}
 \item It may not be possible to read the contents of the Program Buffer using
 the {\tt progbuf} registers. \PR{731}
+\item \RcsrTcontrol fields apply to all traps, not just breakpoint traps. This
+    reverts \PR{723}. \PR{880}
 \end{steps}
 
 \section{About This Document}

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -196,7 +196,7 @@
             regarding triggers with action=0 firing in M-mode trap handlers. See
             Section~\ref{sec:nativetrigger} for more details.
 
-            When a breakpoint trap into M-mode is taken, \FcsrTcontrolMpte is set to the value of
+            When any trap into M-mode is taken, \FcsrTcontrolMpte is set to the value of
             \FcsrTcontrolMte.
         </field>
         <field name="0" bits="6:4" access="R" reset="0" />
@@ -211,7 +211,7 @@
                 Triggers do match/fire while the hart is in M-mode.
             </value>
 
-            When a breakpoint trap into M-mode is taken, \FcsrTcontrolMte is set to 0. When {\tt
+            When any trap into M-mode is taken, \FcsrTcontrolMte is set to 0. When {\tt
             mret} is executed, \FcsrTcontrolMte is set to the value of \FcsrTcontrolMpte.
         </field>
         <field name="0" bits="2:0" access="R" reset="0" />


### PR DESCRIPTION
Reverts #723, which would result in mepc etc. being clobbered if a breakpoint trigger would fire in the most privileged mode.

Specifically, consider:
1. icount is set so that it'll trigger on the first instruction of an exception handler.
2. Code takes an exception, saving mepc etc.
3. Now icount fires causing a breakpoint exception, clobbering mepc.