### PR TITLE
AR: Clarify triggers and multiple state changes

### DIFF
--- a/Sdtrig.tex
+++ b/Sdtrig.tex
@@ -319,6 +319,24 @@ Cache operations encoded as HINTs do not match debug triggers.
     \end{steps}
 \end{commentary}
 
+\section{Multiple State Change Instructions} \label{sec:multistate}
+
+An instruction that performs multiple architectural state changes (e.g.,
+register updates and/or memory accesses) might cause a trigger to fire at an
+intermediate point in its execution. As a result, architectural state changes up
+to that point might have been performed, while subsequent state changes,
+starting from the event that activated the trigger, might not have been. The
+definition of such an instruction will specify the order in which architectural
+state changes take place. Alternatively, it may state that partial execution is
+not allowed, implying that a mid-execution trigger must prevent any
+architectural state changes from occurring.
+
+Debuggers won't be aware if an instruction has been partially executed. When
+they resume execution, they will execute the same instruction once more.
+Therefore, it's crucial that partially executing the instruction and then
+executing it again leaves the hart in a state closely resembling the state it
+would have been in if the instruction had only been executed once.
+
 \section{Trigger Registers}
 
 These registers are CSRs, accessible using the RISC-V {\tt csr} opcodes and

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -754,21 +754,11 @@
             <value v="1" name="before">
             The trigger fired before the instruction that matched it was
             retired, but after all preceding instructions are retired. This
-            explicitly allows for instructions to be partially executed.
+            explicitly allows for instructions to be partially executed, as
+            described in Section \ref{sec:multistate}.
+
             \Rxepc or \RcsrDpc (depending on \FcsrMcontrolSixAction) must be set
             to the virtual address of the instruction that matched.
-
-            An instruction that caused a trigger to fire might be executed
-            partially. In that case not all memory accesses may have been
-            performed, and some registers may not have been updated. Executing
-            that instruction again must have the same result as fully executing
-            it the first time would have, except for any effects due to
-            non-idempotent memory. Implementations should avoid partial
-            instruction execution, but it might be unavoidable for instructions
-            that perform a large number of operations.
-
-            For vector instructions, the vstart mechanism can be used to handle
-            partial execution without duplicating memory accesses.
             </value>
 
             <value v="2" name="after">


### PR DESCRIPTION
Incorporate more feedback from AR. Moved this into a separate Sdtrig section, since the discussion could also apply to instructions that cause triggers beside memory access ones. (E.g. an instruction that combines memory accesses with a trigger, and itrigger.)

Follow up to #883.