### PR TITLE
AR: Clarify itrigger behavior.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -1145,11 +1145,13 @@
         interrupt. (E.g.\  it does not fire when a timer interrupt occurs but that
         interrupt is not enabled in \Rmie.)
 
-        When the trigger fires, all CSRs are updated for the interrupt trap as defined by the
-        Privileged Spec, and the requested action is taken just before the
-        first instruction of the trap handler is executed.
-        If the trigger fires with \FcsrItriggerAction=0 then zero is written to the
-        {\tt tval} CSR on the breakpoint trap (see ~\ref{sec:nativetrigger}).
+        When the trigger matches, it fires after the trap occurs, just before
+        the first instruction of the trap handler is executed.  If
+        \FcsrItriggerAction=0, the standard CSRs are updated for taking the
+        breakpoint trap, and zero is written to the relevant {\tt tval} CSR.  If
+        the breakpoint trap does not go to a higher privilege mode, this will
+        lose CSR information for the original trap.  See
+        Section~\ref{sec:nativetrigger} for more information about this case.
 
         If \RcsrTextraThirtytwo or \RcsrTextraSixtyfour are implemented for this
         trigger, it only matches when the conditions set there are satisfied.
@@ -1224,11 +1226,13 @@
         back \RcsrTdataTwo after writing it to confirm the requested functionality
         is actually supported.
 
-        When the trigger fires, all CSRs are updated for the exception as defined by the
-        Privileged Spec, and the requested action is taken just before the
-        first instruction of the trap handler is executed.
-        If the trigger fires with \FcsrEtriggerAction=0 then zero is written to the
-        {\tt tval} CSR on the breakpoint trap (see ~\ref{sec:nativetrigger}).
+        When the trigger matches, it fires after the trap occurs, just before
+        the first instruction of the trap handler is executed.  If
+        \FcsrEtriggerAction=0, the standard CSRs are updated for taking the
+        breakpoint trap, and zero is written to the relevant {\tt tval} CSR.  If
+        the breakpoint trap does not go to a higher privilege mode, this will
+        lose CSR information for the original trap.  See
+        Section~\ref{sec:nativetrigger} for more information about this case.
 
         If \RcsrTextraThirtytwo or \RcsrTextraSixtyfour are implemented for this
         trigger, it only matches when the conditions set there are satisfied.


### PR DESCRIPTION
Specifically, make clear that itrigger fires *after* the original exception has finished updating all the CSRs.

Hopefully resolves #890.