### PR TITLE
Make register dump output more concise.

### DIFF
--- a/debug_reg_printer.c
+++ b/debug_reg_printer.c
@@ -62,22 +62,35 @@ static uint64_t riscv_debug_reg_field_value(riscv_debug_reg_field_info_t field, 
 
 static unsigned int riscv_debug_reg_fields_to_s(char *buf, unsigned int offset,
 	struct riscv_debug_reg_field_list_t (*get_next)(riscv_debug_reg_ctx_t contex),
-	riscv_debug_reg_ctx_t context, uint64_t value)
+	riscv_debug_reg_ctx_t context, uint64_t value,
+	enum riscv_debug_reg_show show)
 {
 	unsigned int curr = offset;
-	curr += get_len_or_sprintf(buf, curr, " { ");
+	curr += get_len_or_sprintf(buf, curr, " {");
+	char *separator = "";
 	for (struct riscv_debug_reg_field_list_t list; get_next; get_next = list.get_next) {
 		list = get_next(context);
-		curr += riscv_debug_reg_field_to_s(buf, curr, list.field, context,
-				riscv_debug_reg_field_value(list.field, value));
-		curr += get_len_or_sprintf(buf, curr, ", ");
+
+		uint64_t field_value = riscv_debug_reg_field_value(list.field, value);
+
+		if ((show == RISCV_DEBUG_REG_SHOW_ALL) ||
+				(show == RISCV_DEBUG_REG_HIDE_UNNAMED_0 &&
+					(field_value != 0 ||
+						(list.field.values && list.field.values[0]))) ||
+				(show == RISCV_DEBUG_REG_HIDE_ALL_0 && field_value != 0)) {
+			curr += get_len_or_sprintf(buf, curr, separator);
+			curr += riscv_debug_reg_field_to_s(buf, curr, list.field, context,
+							field_value);
+			separator = " ";
+		}
 	}
 	curr += get_len_or_sprintf(buf, curr, "}");
 	return curr - offset;
 }
 
 unsigned int riscv_debug_reg_to_s(char *buf, enum riscv_debug_reg_ordinal reg_ordinal,
-		riscv_debug_reg_ctx_t context, uint64_t value)
+		riscv_debug_reg_ctx_t context, uint64_t value,
+		enum riscv_debug_reg_show show)
 {
 	unsigned int length = 0;
 
@@ -88,7 +101,7 @@ unsigned int riscv_debug_reg_to_s(char *buf, enum riscv_debug_reg_ordinal reg_or
 
 	if (reg.get_fields_head)
 		length += riscv_debug_reg_fields_to_s(buf, length,
-				reg.get_fields_head, context, value);
+				reg.get_fields_head, context, value, show);
 
 	if (buf)
 		buf[length] = '\0';

--- a/debug_reg_printer.h
+++ b/debug_reg_printer.h
@@ -2,6 +2,12 @@
 
 #include "debug_defines.h"
 
+enum riscv_debug_reg_show {
+	RISCV_DEBUG_REG_SHOW_ALL,
+	RISCV_DEBUG_REG_HIDE_ALL_0,
+	RISCV_DEBUG_REG_HIDE_UNNAMED_0,
+};
+
 /**
  * This function is used to fill a buffer with a decoded string representation
  * of register's value.
@@ -25,4 +31,5 @@
  * riscv_debug_reg_to_s(buf, DTM_DMI_ORDINAL, context, <dmi value>);
  */
 unsigned int riscv_debug_reg_to_s(char *buf, enum riscv_debug_reg_ordinal reg_ordinal,
-		riscv_debug_reg_ctx_t context, uint64_t value);
+		riscv_debug_reg_ctx_t context, uint64_t value,
+		enum riscv_debug_reg_show show);

--- a/registers.py
+++ b/registers.py
@@ -242,7 +242,12 @@ class Field( object ):
 
     def c_values_array_def(self):
         assert len(self.values)
-        arr_elem_def = (f'[{v.value}] = "{v.name}"' for v in self.values if v.value is not None)
+
+        # Remove whitespace from the names, so when they're displayed we can use
+        # only ' ' as a separator.
+        arr_elem_def = (f'[{v.value}] = "{toCIdentifier(v.name)}"'
+                        for v in self.values if v.value is not None)
+
         #WA for *lo & *hi splitted fields
         if len(self.values) > 2**self.length():
             return f"static const char *{self.c_values_array_name()}[{2**self.length()}] = {{}};"


### PR DESCRIPTION
Don't mention fields whose value is 0.
New format:
{sbautoincrement=1 sbaccess=64bit sbreadonaddr=1 }