### PR TITLE
uncertain is updated when trigger fires.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -712,8 +712,8 @@
         <field name="dmode" bits="XLEN-5" access="WARL" reset="0" />
         <field name="0" bits="XLEN-6:27" access="R" reset="0" />
         <field name="uncertain" bits="26" access="WARL" reset="0">
-            This bit should be updated every time that \FcsrMcontrolSixHitZero
-            or \FcsrMcontrolSixHitOne is updated.
+            If implemented, the TM updates this field every time the trigger
+            fires.
 
             <value v="0" name="certain">
                 The trigger that fired satisfied the configured conditions, or


### PR DESCRIPTION
Don't make this contingent on hit0/hit1 being changed, since those bits are optional. (Although I discourage anyone from not implementing hit0/hit1.)

Addresses #915.