### PR TITLE
Call registers.py during build to convert XML to adoc.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # Step 0: Install build requirements
+    - name: Install Build Requirements
+      run: sudo apt-get install -y python3-sympy
+
     # Step 1: Checkout the repository
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/build/Makefile
+++ b/build/Makefile
@@ -18,6 +18,14 @@ riscvintl/riscv-docs-base-container-image:latest
 
 HEADER_SOURCE := riscv-debug-header.adoc
 PDF_RESULT := ./build/riscv-debug-specification.pdf
+REGISTERS_ADOC = jtag_registers.adoc
+REGISTERS_ADOC += core_registers.adoc
+REGISTERS_ADOC += hwbp_registers.adoc
+REGISTERS_ADOC += dm_registers.adoc
+REGISTERS_ADOC += sample_registers.adoc
+REGISTERS_ADOC += abstract_commands.adoc
+REGISTERS_ADOC += sw_registers.adoc
+REGISTERS_PY = ../registers.py
 
 ASCIIDOCTOR_PDF := asciidoctor-pdf
 OPTIONS := --trace \
@@ -43,15 +51,20 @@ build:
 		$(MAKE) build-no-container; \
 	fi
 
-build-container:
+build-container:	build-registers
 	@echo "Starting build inside Docker container..."
 	$(DOCKER_RUN) /bin/sh -c "$(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) --out-file=$(PDF_RESULT) $(HEADER_SOURCE)"
 	@echo "Build completed successfully inside Docker container."
 
-build-no-container:
+build-no-container:	build-registers
 	@echo "Starting build..."
 	$(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) --out-file=$(PDF_RESULT) $(HEADER_SOURCE)
 	@echo "Build completed successfully."
+
+build-registers:	$(REGISTERS_ADOC)
+
+%.adoc:	../xml/%.xml $(REGISTERS_PY)
+	../registers.py --adoc $< > $@
 
 clean:
 	@echo "Cleaning up generated files..."

--- a/jtagdtm.adoc
+++ b/jtagdtm.adoc
@@ -32,6 +32,8 @@ are BYPASS and IDCODE, but this specification leaves IR space for many
 other standard JTAG instructions. Unimplemented instructions must select
 the BYPASS register.
 
+include::build/jtag_registers.adoc[]
+
 === JTAG Connector
 
 ==== Recommended JTAG Connector

--- a/registers.py
+++ b/registers.py
@@ -809,15 +809,15 @@ def print_adoc( registers ):
         if r.short:
             # TODO: Check that (((foo))) renders as ((foo)) inside parens
             if r.address:
-                print(f"={sub} {r.name} ((({r.short})), at {r.address})")
+                print(f"==={sub} {r.name} ((({r.short})), at {r.address})")
             else:
-                print(f"={sub} {r.name} ((({r.short})))")
+                print(f"==={sub} {r.name} ((({r.short})))")
             # TODO: confirm that index works
         else:
             if r.address:
-                print("={sub} ((`{r.name}`)) (at {r.address})")
+                print(f"==={sub} ((`{r.name}`)) (at {r.address})")
             else:
-                print("={sub} ((`{r.name}`))")
+                print(f"==={sub} ((`{r.name}`))")
         print()
         if r.label and r.define:
             print("[[%s]]" % toLatexIdentifier(registers.prefix, r.label))


### PR DESCRIPTION
Only used for JTAG registers right now since they're missing from adoc altogether. This is mostly a proof of concept of the workflow. There is definitely some formatting issues with the generated adoc, which should be trivial to adjust once I know what correct adoc looks like.