### PR TITLE
Add <diagram> option to <register> entries.

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -45,6 +45,8 @@ class Register( object ):
         self.address = address
         self.sdesc = sdesc
         self.define = define
+        # Allow user to override our auto-generated register diagram.
+        self.diagram = None
         self.fields = []
 
         self.label = ( short or name ).lower() # TODO: replace spaces etc.
@@ -330,6 +332,9 @@ def parse_xml( path ):
                     f.get( 'access' ), description, f.get( 'sdesc' ),
                     define, values )
             register.add_field( field )
+
+        for diagram in r.findall( 'diagram' ):
+            register.diagram = diagram.text.strip()
 
         register.check()
         registers.add_register( register )
@@ -935,6 +940,8 @@ def write_adoc( fd, registers ):
         fd.write(remove_indent(r.description))
         fd.write("\n")
 
+        if r.diagram:
+            fd.write(f"{remove_indent(r.diagram)}\n")
         if r.fields:
             if registers.prefix == "CSR_":
                 if int(r.address, 0) >= 0xc00:

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -43,6 +43,27 @@
         If this trigger supports multiple types, then the hardware should
         disable it by changing {tdata1-type} to 15.
 
+        <!-- Just an example of how <diagram> works. This is exactly what is
+        auto-generated, so doesn't actually change the net output. -->
+        <diagram>
+            [bytefield]
+            ----
+            (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
+            (def row-height 45)
+            (def row-header-fn nil)
+            (def boxes-per-row 24)
+            (draw-column-headers {:labels ["XLEN-1" "" "" "" "XLEN-4" "" "XLEN-5" "" "XLEN-6" "" "" "" "" "" "" "" "0" "" "" "" "" "" "" ""]})
+            (draw-box "type" {:span 5})
+            (draw-box "dmode" {:span 3})
+            (draw-box "data" {:span 9})
+            (draw-box "" {:span 7 :borders {}})
+            (draw-box "4" {:span 5 :borders {}})
+            (draw-box "1" {:span 3 :borders {}})
+            (draw-box "XLEN - 5" {:span 9 :borders {}})
+            (draw-box "" {:span 7 :borders {}})
+            ----
+        </diagram>
+
         <field name="type" bits="XLEN-1:XLEN-4" access="WARL" reset="Preset">
             <value v="0" name="none">
             There is no trigger at this {csr-tselect}.


### PR DESCRIPTION
This enables us to override the auto-generated diagram when it doesn't do a good job.

Hopefully we won't need it much. If we do, the auto-generation code probably needs improvement.