### PR TITLE
Misc asciidoc fixes.

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -293,7 +293,7 @@ increase the values in the version fields.
 ====
 
 Names of registers and their fields are hyperlinks to their definition,
-and are also listed in the index on page <<singlestep>>.
+and are also listed in the <<index>>.
 
 include::build/sample_registers.adoc[]
 

--- a/registers.py
+++ b/registers.py
@@ -949,7 +949,7 @@ def write_adoc( fd, registers ):
                 fd.write(f"==={sub} ((`{r.name}`))\n")
         fd.write("\n")
         fd.write(remove_indent(r.description))
-        fd.write("\n")
+        fd.write("\n\n")
 
         if r.diagram:
             fd.write(f"{remove_indent(r.diagram)}\n")

--- a/riscv-debug-header.adoc
+++ b/riscv-debug-header.adoc
@@ -4,7 +4,7 @@
 :company: RISC-V.org
 :authors: Editors: Paul Donahue <pdonahue@ventanamicro.com>, Ventana Micro Systems, Tim Newsome <tim@casualhacker.net>, Individual Member
 :revdate: Revised 2024-01-25
-:revnumber: 1.0.0-rc0
+:revnumber: 1.0.0-rc1
 :revremark: Frozen
 :url-riscv: http://riscv.org
 :doctype: book

--- a/riscv-debug-header.adoc
+++ b/riscv-debug-header.adoc
@@ -101,5 +101,9 @@ include::debugger_implementation.adoc[]
 //include::index.adoc[]
 //include::bibliography.adoc[]
 
+// The link target for referencing the index
+[[index]]
+// The index
 [index]
+// The title for the index
 == Index

--- a/riscv-debug-header.adoc
+++ b/riscv-debug-header.adoc
@@ -2,7 +2,7 @@
 = The RISC-V Debug Specification
 :description: RISC-V Debug Specification
 :company: RISC-V.org
-:authors: Editors: Paul Donahue <pdonahue@ventanamicro.com>, Ventana Micro Systems, Tim Newsome <tim@casualhacker.net>, Individual Member
+:authors: Tim Newsome <tim@casualhacker.net>; Paul Donahue <pdonahue@ventanamicro.com>, Ventana Micro Systems
 :revdate: Revised 2024-01-25
 :revnumber: 1.0.0-rc1
 :revremark: Frozen

--- a/riscv-debug-header.adoc
+++ b/riscv-debug-header.adoc
@@ -2,7 +2,7 @@
 = The RISC-V Debug Specification
 :description: RISC-V Debug Specification
 :company: RISC-V.org
-:authors: Tim Newsome <tim@casualhacker.net>; Paul Donahue <pdonahue@ventanamicro.com>, Ventana Micro Systems
+:authors: Tim Newsome, Paul Donahue (Ventana Micro Systems)
 :revdate: Revised 2024-01-25
 :revnumber: 1.0.0-rc1
 :revremark: Frozen


### PR DESCRIPTION
The only text change is on the title page. My name is now first, and I removed email addresses because they just don't work with whatever `:authors:` does.