### PR TITLE
Dual-license XML files BSD-2-Clause and CC-BY-4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,10 @@
+All files in this repo may be used under the CC-BY-4.0 license, included below.
+Some files may also be used under a different license. Where that is the case,
+they contain a comment near the top of the file specifying the other license.
+Use under any other license is prohibited.
+
+CC-BY-4.0 license:
+
 Attribution 4.0 International
 
 =======================================================================

--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -1,3 +1,15 @@
+<!--
+This file is dual-licensed. You may choose to use this file under the terms of either the:
+
+1. SPDX-License-Identifier: BSD-2-Clause
+
+OR
+
+2. SPDX-License-Identifier: CC-BY-4.0
+
+Note: This dual licensing does not apply to other files that may be part of the same project unless stated otherwise.
+-->
+
 <registers name="Abstract Commands" skip_index="1" skip_access="1"
         skip_reset="1" prefix="AC_" depth="2">
     <register name="Access Register">

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -1,3 +1,15 @@
+<!--
+This file is dual-licensed. You may choose to use this file under the terms of either the:
+
+1. SPDX-License-Identifier: BSD-2-Clause
+
+OR
+
+2. SPDX-License-Identifier: CC-BY-4.0
+
+Note: This dual licensing does not apply to other files that may be part of the same project unless stated otherwise.
+-->
+
 <registers name="Core Debug Registers" prefix="CSR_">
     These registers are only accessible from Debug Mode.
 

--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -1,3 +1,15 @@
+<!--
+This file is dual-licensed. You may choose to use this file under the terms of either the:
+
+1. SPDX-License-Identifier: BSD-2-Clause
+
+OR
+
+2. SPDX-License-Identifier: CC-BY-4.0
+
+Note: This dual licensing does not apply to other files that may be part of the same project unless stated otherwise.
+-->
+
 <registers name="Debug Module Debug Bus Registers" prefix="DM_">
 
     <!-- =============== halt/reset/select hart  =============== -->

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -1,3 +1,15 @@
+<!--
+This file is dual-licensed. You may choose to use this file under the terms of either the:
+
+1. SPDX-License-Identifier: BSD-2-Clause
+
+OR
+
+2. SPDX-License-Identifier: CC-BY-4.0
+
+Note: This dual licensing does not apply to other files that may be part of the same project unless stated otherwise.
+-->
+
 <registers name="Trigger Module Registers" prefix="CSR_" label="trigger">
     The Trigger Module registers, except \RcsrMscontext, \RcsrScontext, and \RcsrHcontext, are only accessible in machine
     and Debug Mode to prevent untrusted user code from causing entry into Debug

--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -1,3 +1,15 @@
+<!--
+This file is dual-licensed. You may choose to use this file under the terms of either the:
+
+1. SPDX-License-Identifier: BSD-2-Clause
+
+OR
+
+2. SPDX-License-Identifier: CC-BY-4.0
+
+Note: This dual licensing does not apply to other files that may be part of the same project unless stated otherwise.
+-->
+
 <registers name="JTAG DTM TAP Registers" label="table:jtag_registers" prefix="DTM_">
     <!-- JTAG standard registers, everything starting with 0 -->
     <register name="BYPASS" address="0x00" sdesc="JTAG recommends this encoding"/>

--- a/xml/sample_registers.xml
+++ b/xml/sample_registers.xml
@@ -1,3 +1,15 @@
+<!--
+This file is dual-licensed. You may choose to use this file under the terms of either the:
+
+1. SPDX-License-Identifier: BSD-2-Clause
+
+OR
+
+2. SPDX-License-Identifier: CC-BY-4.0
+
+Note: This dual licensing does not apply to other files that may be part of the same project unless stated otherwise.
+-->
+
 <registers name="Sample Registers" skip_index="1" depth="2">
     Description of what this register is about.
     <register name="Long Name" short="shortname" address="0x123">

--- a/xml/sw_registers.xml
+++ b/xml/sw_registers.xml
@@ -1,3 +1,15 @@
+<!--
+This file is dual-licensed. You may choose to use this file under the terms of either the:
+
+1. SPDX-License-Identifier: BSD-2-Clause
+
+OR
+
+2. SPDX-License-Identifier: CC-BY-4.0
+
+Note: This dual licensing does not apply to other files that may be part of the same project unless stated otherwise.
+-->
+
 <registers name="Virtual Core Debug Registers" prefix="VIRT_">
     A virtual register is one that doesn't exist directly in the hardware, but
     that the debugger exposes as if it does. Debug software should implement


### PR DESCRIPTION
BSD-2-Clause is used so the C code generated from those files can be used in GPLv2 open source projects (specifically, OpenOCD) and the CC-BY-4.0 clause is the standard license for work produced by the RISC-V Foundation.