### PR TITLE
Ensure a newline at the end of registers description

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -1017,7 +1017,7 @@ def write_adoc( fd, registers ):
         fd.write("\n")
 
 def write_adoc_index( fd, registers ):
-    fd.write(remove_indent(registers.description))
+    fd.write(remove_indent(registers.description) + "\n")
 
     columns = [
         ("Address", "1"),


### PR DESCRIPTION
Without this, the `[cols=...]` line would show up in the rendered text (at the start of section 4.10).