### PR TITLE
Remove Section 4.9: XLEN

### DIFF
--- a/Sdext.adoc
+++ b/Sdext.adoc
@@ -194,12 +194,6 @@ specified by {dcsr-prv} and {dcsr-v}.
 . If the new privilege mode is less privileged than M-mode, `MPRV` in `mstatus` is cleared.
 . The hart is no longer in debug mode.
 
-=== XLEN
-
-While in Debug Mode, XLEN is DXLEN. It is up to the debugger to
-determine the XLEN during normal program execution (by looking at `misa`) and
-to clearly communicate this to the user.
-
 [[debreg]]
 === Core Debug Registers
 


### PR DESCRIPTION
Section 4.1 already says "Effective XLEN is DXLEN." The statement about communicating XLEN to the user is unnecessary to the spec, and unclear, so we don't need it.