### PR TITLE
Add support for Smdbltrp.

### DIFF
--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -78,7 +78,35 @@ same project unless stated otherwise.
             All values are reserved for future versions of this spec, or for use
             by other RISC-V extensions.
         </field>
-        <field name="0" bits="23:18" access="R" reset="0" />
+        <field name="0" bits="23:20" access="R" reset="0" />
+        <field name="cetrig" bits="19" access="R/W" reset="0">
+            This bit is part of ((Smdbltrp)) and only exists when that extension
+            is implemented.
+
+            <value v="0" name="disabled">
+                A hart in a critical error state does not enter Debug Mode but
+                instead asserts the critical-error signal to the platform.
+            </value>
+
+            <value v="1" name="enabled">
+                A hart in a critical error state enters Debug Mode instead of
+                asserting the critical-error signal to the platform. Upon such
+                entry into Debug Mode, the cause field is set to 7, and the
+                extcause field is set to 0, indicating a critical error
+                triggered the Debug Mode entry.  This cause has the highest
+                priority among all reasons for entering Debug Mode. Resuming
+                from Debug Mode following an entry from the critical error state
+                returns the hart to the critical error state.
+            </value>
+
+            [NOTE]
+            ====
+                When {dcsr-cetrig} is enabled, resuming from Debug Mode
+                following an entry due to a critical error will result in an
+                immediate re-entry into Debug Mode due to the critical error.
+            ====
+        </field>
+        <field name="0" bits="18" access="R" reset="0" />
         <field name="ebreakvs" bits="17" access="WARL" reset="0">
             <value v="0" name="exception">
             `ebreak` instructions in VS-mode behave as described in the

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -70,7 +70,19 @@ same project unless stated otherwise.
             available version of this spec.
             </value>
         </field>
-        <field name="0" bits="27:18" access="R" reset="0" />
+        <field name="0" bits="27:21" access="R" reset="0" />
+        <field name="extcause" bits="20:18" access="R" reset="0">
+            When {dcsr-cause} is 7, this optional field contains the value of a
+            more specific halt reason than "other." Otherwise it contains 0.
+
+            <value v="0" name="none">
+            There is no more specific halt reason, probably because the hardware
+            does not implement this field.
+            </value>
+
+            Other values are reserved for future versions of this spec, or for
+            use by other RISC-V extensions.
+        </field>
         <field name="ebreakvs" bits="17" access="WARL" reset="0">
             <value v="0" name="exception">
             `ebreak` instructions in VS-mode behave as described in the
@@ -212,7 +224,10 @@ same project unless stated otherwise.
             Harts may report 3 for this cause instead.
             </value>
 
-            Other values are reserved for future use.
+            <value v="7" name="other">
+            The hart halted for a reason other than the ones mentioned above.
+            {dcsr-extcause} may contain a more specific reason.
+            </value>
         </field>
         <field name="v" bits="5" access="WARL" reset="0">
           Extends the prv field with the virtualization mode the hart was operating

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -76,7 +76,7 @@ same project unless stated otherwise.
             more specific halt reason than "other." Otherwise it contains 0.
 
             <value v="0" name="critical error">
-                The hart entered a critical error state. Part of the
+                The hart entered a critical error state, as defined in the
                 ((Smdbltrp)) extension.
             </value>
 
@@ -106,9 +106,13 @@ same project unless stated otherwise.
 
             [NOTE]
             ====
-                When {dcsr-cetrig} is enabled, resuming from Debug Mode
+                When {dcsr-cetrig} is 1, resuming from Debug Mode
                 following an entry due to a critical error will result in an
                 immediate re-entry into Debug Mode due to the critical error.
+                The debugger may resume with {dcsr-cetrig} set to 0 to allow the
+                platform defined actions on critical-error signal to occur.
+                Other possible actions include initiating a hart or platform
+                reset using the Debug Module reset control.
             ====
         </field>
         <field name="0" bits="18" access="R" reset="0" />

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -75,8 +75,13 @@ same project unless stated otherwise.
             When {dcsr-cause} is 7, this optional field contains the value of a
             more specific halt reason than "other." Otherwise it contains 0.
 
-            All values are reserved for future versions of this spec, or for use
-            by other RISC-V extensions.
+            <value v="0" name="critical error">
+                The hart entered a critical error state. Part of the
+                ((Smdbltrp)) extension.
+            </value>
+
+            All other values are reserved for future versions of this spec, or
+            for use by other RISC-V extensions.
         </field>
         <field name="0" bits="23:20" access="R" reset="0" />
         <field name="cetrig" bits="19" access="R/W" reset="0">

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -70,19 +70,15 @@ same project unless stated otherwise.
             available version of this spec.
             </value>
         </field>
-        <field name="0" bits="27:21" access="R" reset="0" />
-        <field name="extcause" bits="20:18" access="R" reset="0">
+        <field name="0" bits="27" access="R" reset="0" />
+        <field name="extcause" bits="26:24" access="R" reset="0">
             When {dcsr-cause} is 7, this optional field contains the value of a
             more specific halt reason than "other." Otherwise it contains 0.
 
-            <value v="0" name="none">
-            There is no more specific halt reason, probably because the hardware
-            does not implement this field.
-            </value>
-
-            Other values are reserved for future versions of this spec, or for
-            use by other RISC-V extensions.
+            All values are reserved for future versions of this spec, or for use
+            by other RISC-V extensions.
         </field>
+        <field name="0" bits="23:18" access="R" reset="0" />
         <field name="ebreakvs" bits="17" access="WARL" reset="0">
             <value v="0" name="exception">
             `ebreak` instructions in VS-mode behave as described in the


### PR DESCRIPTION
2 changes:
1. Add extcause field, which gives is room for a double trap cause plus a few others in case of future need.
2. Add cetrig bit to let a debugger control behavior when a double trap occurs.

We expect this to be approved together with #988, but I want to keep them separate so we can easily have one approved/merged without the other.