### PR TITLE
Update maskmax6 detection algorithm to always work

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -698,7 +698,9 @@ same project unless stated otherwise.
         are supported where stem:[{maskmax6} ≥ 1].  The value of maskmax6 can be determined
         by the debugger via the following sequence:
 
-        . Set {mcontrol6-match}=1.
+        . Write {csr-tdata1}=0, in case the current {csr-tdata2} value is not supported with mcontrol6 triggers.
+        . Write {csr-tdata2}=0, which is always supported with mcontrol6 triggers.
+        . Write {csr-tdata1} with {tdata1-type}=mcontrol6 and {mcontrol6-match}=1.
         . Read {mcontrol6-match}. If it is not 1 then NAPOT matching is not supported.
         . Write all ones to {csr-tdata2}.
         . Read {csr-tdata2}. The value of maskmax6 is the index of the most significant 0 bit plus 1.


### PR DESCRIPTION
Previously, the first write of match=1 might fail because the value in tdata2 is incompatible.

Addresses #1014