### PR TITLE
Restore references to `mhartid` in `debug_module.adoc`

### DIFF
--- a/debug_module.adoc
+++ b/debug_module.adoc
@@ -119,8 +119,8 @@ by writing all ones to {hartsel} (assuming the maximum size) and reading back th
 value to see which bits were actually set. Then it selects each hart
 starting from 0 until either {dmstatus-anynonexistent} in {dm-dmstatus} is 1, or the highest index (depending on `HARTSELLEN`) is reached.
 
-The debugger can discover the mapping between hart indices and by using
-the interface to read , or by reading the hardware platform's
+The debugger can discover the mapping between hart indices and `mhartid` by using
+the interface to read `mhartid`, or by reading the hardware platform's
 configuration structure.
 
 ==== Selecting a Single Hart


### PR DESCRIPTION
Seems like these references were lost durining convertion from LaTeX. See https://github.com/riscv/riscv-debug-spec/blob/f510a7dd33317d0eee0f26b4fa082cd43a5ac7ea/debug_module.tex#L125-L126