### PR TITLE
Don't trademark the trigger module

### DIFF
--- a/Sdtrig.adoc
+++ b/Sdtrig.adoc
@@ -3,7 +3,7 @@
 
 This chapter describes the Sdtrig ISA extension, which can be
 implemented independently of functionality described in the other
-chapters. It consists exclusively of the Trigger Module (TM).
+chapters. It consists exclusively of the Trigger Module \(TM).
 
 Triggers can cause a breakpoint exception, entry into Debug Mode, or a
 trace action without having to execute a special instruction. This makes


### PR DESCRIPTION
`(TM)`  seems to show as a trademark in asciidoc (at least in the github renderer). Escaping the opening parenthesis `\(TM)` appears to fix that.