### PR TITLE
Restore references to `command.cmdtype` and `tab:cmdtype` table

### DIFF
--- a/debug_module.adoc
+++ b/debug_module.adoc
@@ -383,9 +383,10 @@ be hung ({abstractcs-busy} never goes low).
 This section describes each of the different abstract commands and how
 their fields should be interpreted when they are written to {dm-command}.
 
-Each abstract command is a 32-bit value. The top 8 bits contain which
-determines the kind of command. {command-cmdtype} lists all commands.
+Each abstract command is a 32-bit value. The top 8 bits contain {command-cmdtype} which
+determines the kind of command. <<tab:cmdtype>> lists all commands.
 
+[[tab:cmdtype]]
 .Meaning of {command-cmdtype}
 [%autowidth,float="center",align="center",cols=">,<",options="header"]
 |===


### PR DESCRIPTION
Seems like these references were lost durining convertion from LaTeX. See https://github.com/riscv/riscv-debug-spec/blob/f510a7dd33317d0eee0f26b4fa082cd43a5ac7ea/debug_module.tex#L405-L406