### PR TITLE
Restore references to `pc` in [3.8. Program Buffer]

### DIFF
--- a/debug_module.adoc
+++ b/debug_module.adoc
@@ -439,7 +439,7 @@ exist in the address space somewhere.
 
 The Program Buffer may be implemented as RAM which is accessible to the
 hart. A debugger can determine if this is the case by executing small
-programs that attempt to write and read back relative to while executing
+programs that attempt to write and read back relative to `pc` while executing
 from the Program Buffer. If so, the debugger has more flexibility in
 what it can do with the program buffer.
 


### PR DESCRIPTION
Seems like these references were lost durining convertion from LaTeX.

See https://github.com/riscv/riscv-debug-spec/blob/f510a7dd33317d0eee0f26b4fa082cd43a5ac7ea/debug_module.tex#L468