### PR TITLE
[3.14.6. Abstract Control and Status] make `busy` a reference

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -451,7 +451,7 @@ same project unless stated otherwise.
     <register name="Abstract Control and Status" short="abstractcs" address="0x16">
         Writing this register while an abstract command is executing causes
         {abstractcs-cmderr} to become 1 (busy) once the command completes
-        (busy becomes 0).
+        ({abstractcs-busy} becomes 0).
 
         [NOTE]
         ====


### PR DESCRIPTION
This makes it clear that the statatement refers to a field of a register, not a name of a value of `abstractcs.cmderr` field.

Moreover, references are used throughout the spec in similar cases.