### PR TITLE
Fix formatting for `mconfigptr`

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -621,7 +621,7 @@ same project unless stated otherwise.
       further specified in this document.
 
       The configuration structure itself is a data structure of the same format
-      as the data structure pointed to by mconfigptr as described in the
+      as the data structure pointed to by `mconfigptr` as described in the
       Privileged Spec.
       <field name="addr" bits="31:0" access="R" reset="Preset"/>
     </register>


### PR DESCRIPTION
Names of registers not defined in this specification are highlighted using backticks throughout the specification.

`mconfigptr` used to be an exception.