### PR TITLE
Restore reference to `time`

### DIFF
--- a/Sdext.adoc
+++ b/Sdext.adoc
@@ -45,7 +45,7 @@ which raise exceptions may partially update the destination register and
 set `vstart` appropriately.
 . Triggers don't match or fire.
 . If {dcsr-stopcount} is 0 then counters continue. If it is 1 then counters are stopped.
-. If {dcsr-stoptime} is 0 then continues to update. If it is 1 then will not update. It will resynchronize with after leaving Debug Mode.
+. If {dcsr-stoptime} is 0 then `time` continues to update. If it is 1 then `time` will not update. It will resynchronize with `time` after leaving Debug Mode.
 . Instructions that place the hart into a stalled state act as a `nop`.
 This includes `wfi`, `wrs.sto`, and `wrs.nto`.
 . Almost all instructions that change the privilege mode have UNSPECIFIED behavior.


### PR DESCRIPTION
Seems like these references were lost durining convertion from LaTeX.

See https://github.com/riscv/riscv-debug-spec/blob/f510a7dd33317d0eee0f26b4fa082cd43a5ac7ea/Sdext.tex#L47-L49