### PR TITLE
Replace "count" with a reference to 'icount.count'

### DIFF
--- a/Sdext.adoc
+++ b/Sdext.adoc
@@ -158,7 +158,7 @@ time to complete.
 This mechanism cleanly supports a system which supports multiple
 privilege levels, where the OS or a debug stub runs in M-Mode while the
 program being debugged runs in a less privileged mode. Systems that only
-support M-Mode can use {csr-icount} as well, but count must be able to count
+support M-Mode can use {csr-icount} as well, but {icount-count} must be able to count
 several instructions (depending on the software implementation). See
 xref:nativestep[].
 


### PR DESCRIPTION
Without the additional formatting the
> but count must be able to count

part seems a bit strange.