### PR TITLE
Drop `dmcontrol` check before abstract command

### DIFF
--- a/debug_module.adoc
+++ b/debug_module.adoc
@@ -366,8 +366,6 @@ failed, the debugger has to look at the state of the DM (e.g. contents
 of {dm-data0}) or hart (e.g. contents of a register modified by a Program Buffer program) to determine which one failed.
 ====
 
-Before starting an abstract command, a debugger must ensure that {dmcontrol-haltreq}, {dmcontrol-resumereq}, and {dmcontrol-ackhavereset} are all 0.
-
 While an abstract command is executing ({abstractcs-busy} in {dm-abstractcs} is high), a debugger must not change {hartsel}, and must not write 1 to {dmcontrol-haltreq}, {dmcontrol-resumereq}, {dmcontrol-ackhavereset}, {dmcontrol-setresethaltreq}, or {dmcontrol-clrresethaltreq}.
 
 If an abstract command does not complete in the expected time and


### PR DESCRIPTION
The check was introduced in #324.

AFAIU, after #361 and #383 were merged made the check became obsolete.

IMHO, the check is confusing and redundant, since all the fields in question are `W1`/`WARZ`, so it can be dropped.