### PR TITLE
Clarify Memory Access acts like data access.

### DIFF
--- a/xml/abstract_commands.xml
+++ b/xml/abstract_commands.xml
@@ -179,10 +179,11 @@ same project unless stated otherwise.
 
     <register name="Access Memory">
         This command lets the debugger perform memory accesses,
-            with the exact same memory view and permissions as the selected
-            hart has. This includes access to hart-local memory-mapped
-            registers, etc. The command performs the following sequence of
-            operations:
+        with the exact same memory view and permissions as performing
+        loads/stores on the selected hart.
+        This includes access to hart-local memory-mapped
+        registers, etc.  The command performs the following sequence of
+        operations:
 
         . Copy data from the memory location specified in `arg1` into the
             `arg0` portion of `data`, if {accessregister-write} is clear.


### PR DESCRIPTION
I'm not sure if this is necessary. Does RISC-V allow data loads to differ from instruction fetches? For a long time any mention of caches was avoided in all specs.

Inspired by #1062.