### PR TITLE
Readme: Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,21 @@ You may be looking for one of the following pre-built PDFs:
 Build Instructions
 ------------------
 
-```
-sudo apt-get install git make python3 python3-sympy graphviz texlive-full
+```bash
+# Install docker and python3-sympy, if not installed already.
+
+# Pull the latest RISC-V Docs container image:
+docker pull riscvintl/riscv-docs-base-container-image:latest
+
+git clone https://github.com/riscv/riscv-debug-spec.git
+cd riscv-debug-spec
+
+# Optionally, check out a specific revision:
+# git checkout <rev>
+
+git submodule update --init --recursive
+
+cd build
 make
 ```
 


### PR DESCRIPTION
The Readme still contained old (pre-adoc) build instructions. Fix it.

Mention also the use of submodules which are needed for the documentation to build.