### PR TITLE
Clarify that "an operation" is a DMI operation.

### DIFF
--- a/xml/jtag_registers.xml
+++ b/xml/jtag_registers.xml
@@ -208,7 +208,7 @@ same project unless stated otherwise.
             </value>
 
             <value v="3" name="busy" duplicate="1">
-            An operation was attempted while a DMI request is still in
+            A DMI operation was attempted while a prior DMI operation was still in
             progress. The data scanned into {dtm-dmi} in this access will be
             ignored. This status is sticky and can be cleared by writing
             {dtmcs-dmireset} in {dtm-dtmcs}. If a debugger sees this status, it


### PR DESCRIPTION
I was contacted by someone who was confused about this situation:
- kick off a DMI operation (e.g. read)
- read DTMCS while the DMI operation is still in progress

The question was whether this should set busy or not.  My understanding is that "an operation was attempted while a DMI request is still in progress" means that a new _DMI operation_ was attempted, not a _JTAG operation_ to read DTMCS.
