### PR TITLE
Sdtrig: Clarify that tinfo.version is a global constant, not per-trigger

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -177,6 +177,13 @@ same project unless stated otherwise.
         <field name="0" bits="XLEN-1:32" access="R" reset="0" />
         <field name="version" bits="31:24" access="R" reset="Preset">
             Contains the version of the Sdtrig extension implemented.
+
+            [NOTE]
+            ====
+            This field refers to the version of the whole Sdtrig extension.
+            For that reason, all triggers contain the same version number.
+            ====
+
             <value v="0" name="0">
                 Supports triggers as described in this spec at commit 5a5c078,
                 made on February 2, 2023.
@@ -195,9 +202,9 @@ same project unless stated otherwise.
         </field>
         <field name="0" bits="23:16" access="R" reset="0" />
         <field name="info" bits="15:0" access="R" reset="Preset">
-            One bit for each possible {tdata1-type} enumerated in {csr-tdata1}. Bit N
-            corresponds to type N. If the bit is set, then that type is
-            supported by the currently selected trigger.
+            One bit for each possible {tdata1-type} enumerated in {csr-tdata1}.
+            Bit N corresponds to type N. If the bit is set, then that type is
+            supported by the currently selected trigger (by {csr-tselect}).
 
             If the currently selected trigger doesn't exist, this field
             contains 1.


### PR DESCRIPTION
The purpose of "tinfo.version" field is apparently to describe the version of the whole Sdtrig implementation. That is, it is a constant unaffected by the current value of tselect CSR. Judging form the original commit that introduced it (0374fd6d9b3e8675694bf99d613f455bee264fae) and from the related mailing list discussion
(https://lists.riscv.org/g/tech-debug/topic/96888390).

However, the sentences

`This register provides access to the trigger selected by tselect.` 
`The reset values listed here apply to every underlying trigger.`

leave certain room for interpretation that "tinfo.version" is a per-trigger constant, not a global one, and could therefore change depending on "tselect".

Remove this ambiguity by rewording the description of "tinfo" CSR and "tinfo.version" field.