### PR TITLE
Better description of how etrigger matches.

### DIFF
--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -1252,11 +1252,13 @@ same project unless stated otherwise.
 
         This register is accessible as {csr-tdata1} when {tdata1-type} is 5.
 
-        This trigger may fire on up to XLEN of the Exception Codes defined in
-        `mcause` (described in the Privileged Spec, with Interrupt=0). Those
-        causes are configured by writing the corresponding bit in {csr-tdata2}.
-        (E.g.  to trap on an illegal instruction, the debugger sets bit 2 in
-        {csr-tdata2}.)
+        This trigger can match when a trap is taken due to an exception.
+
+        The trigger may be configured to match on up to XLEN of the Exception
+        Codes defined in `mcause` (described in the Privileged Spec, with
+        Interrupt=0). Those causes are configured by writing the corresponding
+        bit in {csr-tdata2}. (e.g. to have etrigger match on an illegal
+        instruction trap, the debugger sets bit 2 in {csr-tdata2}.)
 
         [NOTE]
         ====

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -1156,7 +1156,9 @@ same project unless stated otherwise.
 
         This register is accessible as {csr-tdata1} when {tdata1-type} is 4.
 
-        This trigger can fire when an interrupt trap is taken.
+        This trigger will fire when an interrupt trap is taken and the
+        corresponding {csr-tdata2} bit is set as described in the next
+        paragraph.
 
         It can be enabled for individual interrupt numbers by setting the bit
         corresponding to the interrupt number in {csr-tdata2}. The interrupt
@@ -1252,7 +1254,9 @@ same project unless stated otherwise.
 
         This register is accessible as {csr-tdata1} when {tdata1-type} is 5.
 
-        This trigger can match when a trap is taken due to an exception.
+        This trigger will match when an exception trap is taken and the
+        corresponding {csr-tdata2} bit is set as described in the next
+        paragraph.
 
         The trigger may be configured to match on up to XLEN of the Exception
         Codes defined in `mcause` (described in the Privileged Spec, with


### PR DESCRIPTION
The previous language talked about "When the trigger matches" but it never described matching.  It said that it could fire on mcause codes but did that mean a CSR write instruction with a particular mcause value could make it fire?  I think that this is better.

Fixes https://github.com/riscv/riscv-debug-spec/issues/1084.
