### PR TITLE
Fix asciidoc conversion missing word for #1096.

### DIFF
--- a/implementations.adoc
+++ b/implementations.adoc
@@ -64,7 +64,7 @@ take effect before the DM returns {abstractcs-busy} to 0.
 To resume execution, the debug module sets a flag which causes the hart
 to execute a `dret`. `dret` is an instruction that only has meaning
 while in Debug Mode and not executing from the Program Buffer. Its
-recommended encoding is 0x7b200073. When `dret` is executed, is restored
+recommended encoding is 0x7b200073. When `dret` is executed, `pc` is restored
 from {csr-dpc} and normal execution resumes at the privilege set by {dcsr-prv} and {dcsr-v},
 and the ELP state set by {dcsr-pelp}.
 


### PR DESCRIPTION
I don't know if we can just agree that this is inconsequential and merge it, if we should merge it and create another release candidate, or if we should just delay dealing with this PR until after ratification.

Fixes #1096.
