### PR TITLE
registers.py: Fix subtractions in generated C code

### DIFF
--- a/registers.py
+++ b/registers.py
@@ -472,7 +472,22 @@ def sympy_to_c(expression, sym_to_c = lambda s: f"({s})", unsigned=True):
     elif isinstance(expression, sympy.Symbol):
         return sym_to_c(expression)
     elif isinstance(expression, sympy.Add):
-        return "(" + " + ".join(stc(t) for t in reversed(expression.args)) + ")"
+        args = list(reversed(expression.args))
+        result = ""
+        for i in range(len(args)):
+            arg = args[i]
+            is_first = (i == 0)
+            if is_first:
+                result += stc(arg)
+            else:
+                # Simplify additions of negative constants:
+                # Use (a - 1) instead of (a + -1)
+                negative_constant = arg.is_constant() and (arg < 0)
+                result += " - " if negative_constant else " + "
+                if negative_constant:
+                    arg = -arg  # flip to positive
+                result += stc(arg)
+        return "(" + result + ")"
     elif isinstance(expression, sympy.Mul):
         return "(" + " * ".join(stc(t) for t in expression.args) + ")"
     elif isinstance(expression, sympy.Pow):

--- a/registers.py
+++ b/registers.py
@@ -480,13 +480,12 @@ def sympy_to_c(expression, sym_to_c = lambda s: f"({s})", unsigned=True):
             if is_first:
                 result += stc(arg)
             else:
-                # Simplify additions of negative constants:
-                # Use (a - 1) instead of (a + -1)
-                negative_constant = arg.is_constant() and (arg < 0)
-                result += " - " if negative_constant else " + "
-                if negative_constant:
-                    arg = -arg  # flip to positive
-                result += stc(arg)
+                if arg.is_constant() and (arg < 0):
+                    # Simplify additions of negative constants:
+                    # Use (a - 1) instead of (a + -1)
+                    result += " - %s" % stc(-arg)
+                else:
+                    result += " + %s" % stc(arg)
         return "(" + result + ")"
     elif isinstance(expression, sympy.Mul):
         return "(" + " * ".join(stc(t) for t in expression.args) + ")"


### PR DESCRIPTION
The registers.py generator outputs expressions with subtractions into the C code of debug_defines.{h,c} in this form:

```
((XLEN) + -6ULL)
```

Such code may look awkward to code readers and also triggers GCC's `-Wconversion` warnings in the projects that will include these generated C files.

Fix the generator to produce expressions with subtraction in a natural form:

```
((XLEN) - 6ULL)
```