### PR TITLE
Fix the link to `dmstatus.version` in "Minor Changes from 0.13 to 1.0"

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -166,7 +166,7 @@ incompatible, but unlikely to be noticeable:
 
 . {dcsr-stopcount} only applies to hart-local counters.
 https://github.com/riscv/riscv-debug-spec/pull/405[#405]
-. {tinfo-version} may be invalid when {dmcontrol-dmactive}=0.
+. {dmstatus-version} may be invalid when {dmcontrol-dmactive}=0.
 https://github.com/riscv/riscv-debug-spec/pull/414[#414]
 . Address triggers ({csr-mcontrol}) may fire on any accessed address.
 https://github.com/riscv/riscv-debug-spec/pull/421[#421]


### PR DESCRIPTION
The link got broken during LaTeX to AsciiDoc conversion. Link: https://github.com/riscv/riscv-debug-spec/blob/f510a7dd33317d0eee0f26b4fa082cd43a5ac7ea/introduction.tex#L172