### PR TITLE
`dmactive` description should allow system-wide reset

### DIFF
--- a/xml/dm_registers.xml
+++ b/xml/dm_registers.xml
@@ -374,7 +374,8 @@ same project unless stated otherwise.
             </value>
 
             No other mechanism should exist that may result in resetting the
-            Debug Module after power up.
+            Debug Module after power up unless the mechanism also resets all
+            the harts accessible to the DM.
 
             To place the Debug Module into a known state, a debugger should write 0 to {dmcontrol-dmactive},
             poll until {dmcontrol-dmactive} is observed 0, write 1 to {dmcontrol-dmactive}, and


### PR DESCRIPTION
[3.2. Reset Control] allows for a system-wide reset to reset the Debug Module.
Link: https://github.com/riscv/riscv-debug-spec/blob/a4678108534bef5b4fbf51e92acacd08b28c17af/debug_module.adoc?plain=1#L100

However, `dmactive` field description used to prohibit **any** other DM reset mechanism.

The commit fixes this inconsistency.