### PR TITLE
Remove typedef in generated 'debug_defines.h'

### DIFF
--- a/debug_reg_printer.c
+++ b/debug_reg_printer.c
@@ -43,7 +43,7 @@ static unsigned int riscv_debug_reg_field_value_to_s(char *buf, unsigned int off
 }
 
 static unsigned int riscv_debug_reg_field_to_s(char *buf, unsigned int offset,
-		riscv_debug_reg_field_info_t field, riscv_debug_reg_ctx_t context,
+		struct riscv_debug_reg_field_info field, struct riscv_debug_reg_ctx context,
 		uint64_t field_value)
 {
 	const unsigned int name_len = get_len_or_sprintf(buf, offset, "%s=", field.name);
@@ -52,7 +52,7 @@ static unsigned int riscv_debug_reg_field_to_s(char *buf, unsigned int offset,
 			field.values, field_value);
 }
 
-static uint64_t riscv_debug_reg_field_value(riscv_debug_reg_field_info_t field, uint64_t value)
+static uint64_t riscv_debug_reg_field_value(struct riscv_debug_reg_field_info field, uint64_t value)
 {
 	assert(field.msb < 64);
 	assert(field.msb >= field.lsb);
@@ -61,14 +61,14 @@ static uint64_t riscv_debug_reg_field_value(riscv_debug_reg_field_info_t field, 
 }
 
 static unsigned int riscv_debug_reg_fields_to_s(char *buf, unsigned int offset,
-	struct riscv_debug_reg_field_list_t (*get_next)(riscv_debug_reg_ctx_t contex),
-	riscv_debug_reg_ctx_t context, uint64_t value,
+	struct riscv_debug_reg_field_list (*get_next)(struct riscv_debug_reg_ctx contex),
+	struct riscv_debug_reg_ctx context, uint64_t value,
 	enum riscv_debug_reg_show show)
 {
 	unsigned int curr = offset;
 	curr += get_len_or_sprintf(buf, curr, " {");
 	char *separator = "";
-	for (struct riscv_debug_reg_field_list_t list; get_next; get_next = list.get_next) {
+	for (struct riscv_debug_reg_field_list list; get_next; get_next = list.get_next) {
 		list = get_next(context);
 
 		uint64_t field_value = riscv_debug_reg_field_value(list.field, value);
@@ -89,12 +89,12 @@ static unsigned int riscv_debug_reg_fields_to_s(char *buf, unsigned int offset,
 }
 
 unsigned int riscv_debug_reg_to_s(char *buf, enum riscv_debug_reg_ordinal reg_ordinal,
-		riscv_debug_reg_ctx_t context, uint64_t value,
+		struct riscv_debug_reg_ctx context, uint64_t value,
 		enum riscv_debug_reg_show show)
 {
 	unsigned int length = 0;
 
-	riscv_debug_reg_info_t reg = get_riscv_debug_reg_info(reg_ordinal);
+	struct riscv_debug_reg_info reg = get_riscv_debug_reg_info(reg_ordinal);
 
 	length += get_len_or_sprintf(buf, length, "%s=", reg.name);
 	length += print_number(buf, length, value);

--- a/debug_reg_printer.c
+++ b/debug_reg_printer.c
@@ -43,8 +43,7 @@ static unsigned int riscv_debug_reg_field_value_to_s(char *buf, unsigned int off
 }
 
 static unsigned int riscv_debug_reg_field_to_s(char *buf, unsigned int offset,
-		struct riscv_debug_reg_field_info field, struct riscv_debug_reg_ctx context,
-		uint64_t field_value)
+		struct riscv_debug_reg_field_info field, uint64_t field_value)
 {
 	const unsigned int name_len = get_len_or_sprintf(buf, offset, "%s=", field.name);
 
@@ -79,8 +78,7 @@ static unsigned int riscv_debug_reg_fields_to_s(char *buf, unsigned int offset,
 						(list.field.values && list.field.values[0]))) ||
 				(show == RISCV_DEBUG_REG_HIDE_ALL_0 && field_value != 0)) {
 			curr += get_len_or_sprintf(buf, curr, separator);
-			curr += riscv_debug_reg_field_to_s(buf, curr, list.field, context,
-							field_value);
+			curr += riscv_debug_reg_field_to_s(buf, curr, list.field, field_value);
 			separator = " ";
 		}
 	}

--- a/debug_reg_printer.h
+++ b/debug_reg_printer.h
@@ -24,12 +24,12 @@ enum riscv_debug_reg_show {
  * (excluding '\0').
  *
  * Example:
- * const struct riscv_debug_reg_ctx_t context = {
+ * const struct riscv_debug_reg_ctx context = {
  *     .abits = { .value = <abits value>, .is_set = true }
  * };
  * char buf[riscv_debug_reg_to_s(NULL, DTM_DMI_ORDINAL, context, <dmi value>) + 1]
  * riscv_debug_reg_to_s(buf, DTM_DMI_ORDINAL, context, <dmi value>);
  */
 unsigned int riscv_debug_reg_to_s(char *buf, enum riscv_debug_reg_ordinal reg_ordinal,
-		riscv_debug_reg_ctx_t context, uint64_t value,
+		struct riscv_debug_reg_ctx context, uint64_t value,
 		enum riscv_debug_reg_show show);

--- a/registers.py
+++ b/registers.py
@@ -104,10 +104,14 @@ class Register( object ):
 
     @staticmethod
     def c_field_list_type():
-        return ("typedef struct riscv_debug_reg_field_list_t {\n" +
-                "\triscv_debug_reg_field_info_t field;\n" +
-                "\tstruct riscv_debug_reg_field_list_t (*get_next)(riscv_debug_reg_ctx_t context);\n" +
-                "} riscv_debug_reg_field_list_t;\n")
+        return ("struct riscv_debug_reg_field_list {\n" +
+                "\tstruct riscv_debug_reg_field_info field;\n" +
+                "\tstruct riscv_debug_reg_field_list (*get_next)(struct riscv_debug_reg_ctx context);\n" +
+                "};\n" +
+                "/* deprecated, prefer 'struct riscv_debug_reg_field_list' to 'struct riscv_debug_reg_field_list_t' */\n" +
+                "#define riscv_debug_reg_field_list_t riscv_debug_reg_field_list\n" +
+                "/* deprecated, prefer 'struct riscv_debug_reg_field_list' to 'riscv_debug_reg_field_list_t' */\n" +
+                "typedef struct riscv_debug_reg_field_list riscv_debug_reg_field_list_t;\n\n")
     def c_field_getter_names(self):
         fields = list(self.sorted_fields())
         if not len(fields):
@@ -122,10 +126,10 @@ class Register( object ):
             syms = f.symbols()
             all_valid = ' && '.join(map(is_valid, syms))
             field = f.c_info(to_c).replace('\n', '\n\t\t')
-            return (f"static riscv_debug_reg_field_list_t {getter_name}(riscv_debug_reg_ctx_t context)\n" +
+            return (f"static struct riscv_debug_reg_field_list {getter_name}(struct riscv_debug_reg_ctx context)\n" +
                     "{\n\t" +
                     add_indent((f"assert({all_valid});\n" if syms else "") +
-                               f"riscv_debug_reg_field_list_t result = {{\n" +
+                               f"struct riscv_debug_reg_field_list result = {{\n" +
                                f"\t.field = {{\n\t\t{field}\n\t}},\n" +
                                f"\t.get_next = {next_getter_name}\n" +
                                "};\n" +
@@ -141,10 +145,12 @@ class Register( object ):
 
     @staticmethod
     def c_info_type():
-        return ("typedef struct {\n" +
-                "\tconst char *name;\n"
-                "\tstruct riscv_debug_reg_field_list_t (* const get_fields_head)(riscv_debug_reg_ctx_t context);\n" +
-                "} riscv_debug_reg_info_t;\n")
+        return ("struct riscv_debug_reg_info {\n" +
+                "\tconst char *name;\n" +
+                "\tstruct riscv_debug_reg_field_list (* const get_fields_head)(struct riscv_debug_reg_ctx context);\n" +
+                "};\n" +
+                "/* deprecated, prefer 'struct riscv_debug_reg_info' to 'riscv_debug_reg_info_t' */\n" +
+                "typedef struct riscv_debug_reg_info riscv_debug_reg_info_t;\n\n")
 
     def c_info( self, to_c ):
         return (f'.name = "{self.short or self.label}",\n' +
@@ -287,12 +293,14 @@ class Field( object ):
 
     @staticmethod
     def c_info_type():
-        return ("typedef struct {\n" +
+        return ("struct riscv_debug_reg_field_info {\n" +
                 "\tconst char *name;\n" +
                 "\tunsigned int lsb; // inclusive\n" +
                 "\tunsigned int msb; // inclusive\n" +
                 "\tconst char **values; // If non-NULL, array of human-readable string for each possible value\n" +
-                "} riscv_debug_reg_field_info_t;\n")
+                "};\n" +
+                "/* deprecated, prefer 'struct riscv_debug_reg_field_info' to 'riscv_debug_reg_field_info_t' */\n" +
+                "typedef struct riscv_debug_reg_field_info riscv_debug_reg_field_info_t;\n\n")
 
     def c_info( self, to_c ):
         return f'.name = "{self.name}",\n.lsb = {to_c(self.lowBit)},\n.msb = {to_c(self.highBit)},\n.values = {self.c_values_array_name()}'
@@ -561,9 +569,11 @@ def print_cgetters( registers_list, fd_h, fd_c):
              for r in all_regs for f in r.fields if f.to_c_filter()))
 
     gen_sym_struct = lambda s: "struct {\n\t\tunsigned int value; int is_set;\n\t} " + s
-    fd_h.write("typedef struct {\n\t" +
+    fd_h.write("struct riscv_debug_reg_ctx {\n\t" +
                ";\n\t".join(gen_sym_struct(s) for s in sorted((map(lambda sym: str(sym), all_symbols)))) +
-               ";\n} riscv_debug_reg_ctx_t;\n\n")
+               ";\n};\n" +
+               "/* deprecated, prefer 'struct riscv_debug_reg_ctx' to 'riscv_debug_reg_ctx_t' */\n" +
+               "typedef struct riscv_debug_reg_ctx riscv_debug_reg_ctx_t;\n\n")
 
     fd_h.write(Field.c_info_type())
     fd_h.write(Register.c_field_list_type())
@@ -579,11 +589,11 @@ def print_cgetters( registers_list, fd_h, fd_c):
                     fd_c.write(f.c_values_array_def() + "\n");
             fd_c.write(r.c_field_getters(to_c, is_valid) + "\n");
 
-    get_info_func = "riscv_debug_reg_info_t get_riscv_debug_reg_info(enum riscv_debug_reg_ordinal reg_ordinal)"
+    get_info_func = "struct riscv_debug_reg_info get_riscv_debug_reg_info(enum riscv_debug_reg_ordinal reg_ordinal)"
     fd_h.write(get_info_func + ";\n")
     fd_c.write(get_info_func + "\n" +
                "{\n\t" +
-               add_indent("static const riscv_debug_reg_info_t debug_reg_info[] = {\n\t" +
+               add_indent("static const struct riscv_debug_reg_info debug_reg_info[] = {\n\t" +
                           add_indent("\n".join(f"[{r.ordinal_name()}] = {{\n\t{add_indent(r.c_info(to_c))}\n}},"
                                                for r in all_regs)) +
                           "\n};\n" +


### PR DESCRIPTION
The pull request #858 introduces four typedef for some struct in the generated 'debug_defines.h'
Using typedef is not welcome by every project that should include these generated files.
For example, OpenOCD coding style requires not adding new typedef.

This series:
- replaces the typedefs in 'debug_defines.h' with simple 'struct struct_name';
- still defines the old typedef, so existing code will still compile without changes;
- modify the example code in 'debug_reg_printer.c' to use the new data types;
- drop one unused parameter in 'debug_reg_printer.c' that triggers a compile warning.

I still have doubts if I should keep the backward compatibility. Please let me know!