### PR TITLE
Fixed typos

### DIFF
--- a/Sdext.adoc
+++ b/Sdext.adoc
@@ -159,9 +159,9 @@ instructions that read `mstatus`.
 time to complete.
 
 This mechanism cleanly supports a system which supports multiple
-privilege levels, where the OS or a debug stub runs in M-Mode while the
+privilege levels, where the OS or a debug stub runs in M-mode while the
 program being debugged runs in a less privileged mode. Systems that only
-support M-Mode can use {csr-icount} as well, but {icount-count} must be able to count
+support M-mode can use {csr-icount} as well, but {icount-count} must be able to count
 several instructions (depending on the software implementation). See
 xref:nativestep[].
 

--- a/Sdtrig.adoc
+++ b/Sdtrig.adoc
@@ -14,7 +14,7 @@ address/data in loads/stores.
 If Sdtrig is implemented, the Trigger Module must support at least one
 trigger. Accessing trigger CSRs that are not used by any of the
 implemented triggers must result in an illegal instruction exception.
-M-Mode and Debug Mode accesses to trigger CSRs that are used by any of
+M-mode and Debug Mode accesses to trigger CSRs that are used by any of
 the implemented triggers must succeed, regardless of the current type of
 the currently selected trigger.
 
@@ -61,7 +61,7 @@ This action is only legal when the trigger's {mcontrol-dmode} is 1.  Since
 {csr-tdata1} is WARL, hardware must prevent it from containing {tdata1-dmode}=0
 and action=1. +
 This action can only be supported if `Sdext` is implemented on the hart.
-| 2 | Trace on, described in the trace specification. 
+| 2 | Trace on, described in the trace specification.
 | 3 | Trace off, described in the trace specification.
 | 4 | Trace notify, described in the trace specification.
 | 5 | Reserved for use by the trace specification.

--- a/debugger_implementation.adoc
+++ b/debugger_implementation.adoc
@@ -83,19 +83,19 @@ instruction before re-entering Debug Mode.
 Read `s0` using abstract command:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
-|===    
-| Op | Address | Value | Comment    
+|===
+| Op | Address | Value | Comment
 | Write | {dm-command} | {accessregister-aarsize}latexmath:[$=2$], {accessregister-transfer}, {accessregister-regno} = 0x1008 | Read `s0`
-| Read | {dm-data0} | - | Returns value that was in `s0` 
+| Read | {dm-data0} | - | Returns value that was in `s0`
 |===
 
 Write `mstatus` using abstract command:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-data0} | new value | 
-| Write | {dm-command} | {accessregister-aarsize}latexmath:[$=2$], {accessregister-transfer}, {accessregister-write}, {accessregister-regno} = 0x300 | Write `mstatus` 
+| Op | Address | Value | Comment
+| Write | {dm-data0} | new value |
+| Write | {dm-command} | {accessregister-aarsize}latexmath:[$=2$], {accessregister-transfer}, {accessregister-write}, {accessregister-regno} = 0x300 | Write `mstatus`
 |===
 
 [[deb:regprogbuf]]
@@ -109,7 +109,7 @@ Write `mstatus` using program buffer:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
+| Op | Address | Value | Comment
 | Write | {dm-progbuf0} | `csrw s0, MSTATUS` |
 | Write | `progbuf1` | `ebreak` |
 | Write | {dm-data0} | new value |
@@ -120,12 +120,12 @@ Read `f1` using program buffer:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-progbuf0} | {`fmv.x.s s0, f1`} | 
-| Write | `progbuf1` | `ebreak` | 
-| Write | {dm-command} | {accessregister-postexec} | Execute program buffer 
-| Write | {dm-command} | {accessregister-transfer}, {accessregister-regno} = 0x1008 | read `s0` 
-| Read | {dm-data0} | - | Returns the value that was in `f1` 
+| Op | Address | Value | Comment
+| Write | {dm-progbuf0} | {`fmv.x.s s0, f1`} |
+| Write | `progbuf1` | `ebreak` |
+| Write | {dm-command} | {accessregister-postexec} | Execute program buffer
+| Write | {dm-command} | {accessregister-transfer}, {accessregister-regno} = 0x1008 | read `s0`
+| Read | {dm-data0} | - | Returns the value that was in `f1`
 |===
 
 ==== Reading Memory
@@ -139,24 +139,24 @@ Read a word from memory using system bus access:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-sbcs} | {sbcs-sbaccess}latexmath:[$=2$], {sbcs-sbreadonaddr} | Setup 
-| Write | {dm-sbaddress0} | address | 
-| Read | {dm-sbdata0} | - | Value read from memory 
+| Op | Address | Value | Comment
+| Write | {dm-sbcs} | {sbcs-sbaccess}latexmath:[$=2$], {sbcs-sbreadonaddr} | Setup
+| Write | {dm-sbaddress0} | address |
+| Read | {dm-sbdata0} | - | Value read from memory
 |===
 
 Read block of memory using system bus access:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-sbcs} | {sbcs-sbaccess}latexmath:[$=2$], {sbcs-sbreadonaddr}, {sbcs-sbreadondata}, {sbcs-sbautoincrement} | Turn on autoread and autoincrement 
-| Write | {dm-sbaddress0} | address | Writing address triggers read and increment 
-| Read | {dm-sbdata0} | - | Value read from memory 
-| Read | {dm-sbdata0} | - | Next value read from memory 
-| ... | ... | ... | ... 
-| Write | {dm-sbcs} | 0 | Disable autoread 
-| Read | {dm-sbdata0} | - | Get last value read from memory. 
+| Op | Address | Value | Comment
+| Write | {dm-sbcs} | {sbcs-sbaccess}latexmath:[$=2$], {sbcs-sbreadonaddr}, {sbcs-sbreadondata}, {sbcs-sbautoincrement} | Turn on autoread and autoincrement
+| Write | {dm-sbaddress0} | address | Writing address triggers read and increment
+| Read | {dm-sbdata0} | - | Value read from memory
+| Read | {dm-sbdata0} | - | Next value read from memory
+| ... | ... | ... | ...
+| Write | {dm-sbcs} | 0 | Disable autoread
+| Read | {dm-sbdata0} | - | Get last value read from memory.
 |===
 
 [[deb:mrprogbuf]]
@@ -170,32 +170,32 @@ Read a word from memory using program buffer:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-progbuf0} | `lw s0, 0(s0)` | 
-| Write | `progbuf1` | `ebreak` | 
-| Write | {dm-data0} | address | 
-| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-postexec}, {accessregister-regno} = 0x1008 | Write `s0`, then execute program buffer 
-| Write | {dm-command} | {accessregister-regno} = 0x1008 | Read `s0` 
-| Read | {dm-data0} | - | Value read from memory 
+| Op | Address | Value | Comment
+| Write | {dm-progbuf0} | `lw s0, 0(s0)` |
+| Write | `progbuf1` | `ebreak` |
+| Write | {dm-data0} | address |
+| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-postexec}, {accessregister-regno} = 0x1008 | Write `s0`, then execute program buffer
+| Write | {dm-command} | {accessregister-regno} = 0x1008 | Read `s0`
+| Read | {dm-data0} | - | Value read from memory
 |===
 
 Read block of memory using program buffer:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-progbuf0} | `lw s1, 0(s0)` | 
-| Write | `progbuf1` | `addi s0, s1, 4` | 
-| Write | `progbuf2` | `ebreak` | 
-| Write | {dm-data0} | address | 
-| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-postexec}, {accessregister-regno} = 0x1008 | Write `s0`, then execute program buffer 
-| Write | {dm-command} | {accessregister-postexec}, {accessregister-regno} = 0x1009 | Read `s1`, then execute program buffer 
-| Write | {dm-abstractauto} | {abstractauto-autoexecdata}[0] | Set {abstractauto-autoexecdata}[0] 
-| Read | {dm-data0} | - | Get value read from memory, then execute program buffer 
-| Read | {dm-data0} | - | Get next value read from memory, then execute program buffer 
-| ... | ... | ... | ... 
-| Write | {dm-abstractauto} | 0 | Clear {abstractauto-autoexecdata}[0] 
-| Read | {dm-data0} | - | Get last value read from memory. 
+| Op | Address | Value | Comment
+| Write | {dm-progbuf0} | `lw s1, 0(s0)` |
+| Write | `progbuf1` | `addi s0, s1, 4` |
+| Write | `progbuf2` | `ebreak` |
+| Write | {dm-data0} | address |
+| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-postexec}, {accessregister-regno} = 0x1008 | Write `s0`, then execute program buffer
+| Write | {dm-command} | {accessregister-postexec}, {accessregister-regno} = 0x1009 | Read `s1`, then execute program buffer
+| Write | {dm-abstractauto} | {abstractauto-autoexecdata}[0] | Set {abstractauto-autoexecdata}[0]
+| Read | {dm-data0} | - | Get value read from memory, then execute program buffer
+| Read | {dm-data0} | - | Get next value read from memory, then execute program buffer
+| ... | ... | ... | ...
+| Write | {dm-abstractauto} | 0 | Clear {abstractauto-autoexecdata}[0]
+| Read | {dm-data0} | - | Get last value read from memory.
 |===
 
 [[deb:mrabstract]]
@@ -208,24 +208,24 @@ Read a word from memory using abstract memory access:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | `data1` | address | 
-| Write | {dm-command} | cmdtype=2, {accessmemory-aamsize}latexmath:[$=2$] | 
-| Read | {dm-data0} | - | Value read from memory 
+| Op | Address | Value | Comment
+| Write | `data1` | address |
+| Write | {dm-command} | cmdtype=2, {accessmemory-aamsize}latexmath:[$=2$] |
+| Read | {dm-data0} | - | Value read from memory
 |===
 
 Read block of memory using abstract memory access:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-abstractauto} | 1 | Re-execute the command when {dm-data0} is accessed 
-| Write | `data1` | address | 
-| Write | {dm-command} | cmdtype=2, {accessmemory-aamsize}latexmath:[$=2$], {accessmemory-aampostincrement}latexmath:[$=1$] | 
-| Read | {dm-data0} | - | Read value, and trigger reading of next address 
-| ... | ... | ... | ... 
-| Write | {dm-abstractauto} | 0 | Disable auto-exec 
-| Read | {dm-data0} | - | Get last value read from memory. 
+| Op | Address | Value | Comment
+| Write | {dm-abstractauto} | 1 | Re-execute the command when {dm-data0} is accessed
+| Write | `data1` | address |
+| Write | {dm-command} | cmdtype=2, {accessmemory-aamsize}latexmath:[$=2$], {accessmemory-aampostincrement}latexmath:[$=1$] |
+| Read | {dm-data0} | - | Read value, and trigger reading of next address
+| ... | ... | ... | ...
+| Write | {dm-abstractauto} | 0 | Disable auto-exec
+| Read | {dm-data0} | - | Get last value read from memory.
 |===
 
 [[writemem]]
@@ -240,23 +240,23 @@ Write a word to memory using system bus access:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-sbcs} | {sbcs-sbaccess}latexmath:[$=2$] | Configure access size 
-| Write | {dm-sbaddress0} | address | 
-| Write | {dm-sbdata0} | value | 
+| Op | Address | Value | Comment
+| Write | {dm-sbcs} | {sbcs-sbaccess}latexmath:[$=2$] | Configure access size
+| Write | {dm-sbaddress0} | address |
+| Write | {dm-sbdata0} | value |
 |===
 
 Write a block of memory using system bus access:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-sbcs} | {sbcs-sbaccess}latexmath:[$=2$], {sbcs-sbautoincrement} | Turn on autoincrement 
-| Write | {dm-sbaddress0} | address | 
-| Write | {dm-sbdata0} | value0 | 
-| Write | {dm-sbdata0} | value1 | 
-| ... | ... | ... | ... 
-| Write | {dm-sbdata0} | valueN | 
+| Op | Address | Value | Comment
+| Write | {dm-sbcs} | {sbcs-sbaccess}latexmath:[$=2$], {sbcs-sbautoincrement} | Turn on autoincrement
+| Write | {dm-sbaddress0} | address |
+| Write | {dm-sbdata0} | value0 |
+| Write | {dm-sbdata0} | value1 |
+| ... | ... | ... | ...
+| Write | {dm-sbdata0} | valueN |
 |===
 
 [[deb:mrprogbufwrite]]
@@ -270,32 +270,32 @@ Write a word to memory using program buffer:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-progbuf0} | `sw s1, 0(s0)` | 
-| Write | `progbuf1` | `ebreak` | 
-| Write | {dm-data0} | address | 
-| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-regno} = 0x1008 | Write `s0` 
-| Write | {dm-data0} | value | 
-| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-postexec}, {accessregister-regno} = 0x1009 | Write `s1`, then execute program buffer 
+| Op | Address | Value | Comment
+| Write | {dm-progbuf0} | `sw s1, 0(s0)` |
+| Write | `progbuf1` | `ebreak` |
+| Write | {dm-data0} | address |
+| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-regno} = 0x1008 | Write `s0`
+| Write | {dm-data0} | value |
+| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-postexec}, {accessregister-regno} = 0x1009 | Write `s1`, then execute program buffer
 |===
 
 Write block of memory using program buffer:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-progbuf0} | `sw s1, 0(s0)` | 
-| Write | `progbuf1` | `addi s0, s1, 4` | 
-| Write | `progbuf2` | `ebreak` | 
-| Write | {dm-data0} | address | 
-| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-regno} = 0x1008 | Write `s0` 
-| Write | {dm-data0} | value0 | 
-| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-postexec}, {accessregister-regno} = 0x1009 | Write `s1`, then execute program buffer 
-| Write | {dm-abstractauto} | {abstractauto-autoexecdata}[0] | Set {abstractauto-autoexecdata}[0] 
-| Write | {dm-data0} | value1 | 
-| ... | ... | ... | ... 
-| Write | {dm-data0} | valueN | 
-| Write | {dm-abstractauto} | 0 | Clear {abstractauto-autoexecdata}[0] 
+| Op | Address | Value | Comment
+| Write | {dm-progbuf0} | `sw s1, 0(s0)` |
+| Write | `progbuf1` | `addi s0, s1, 4` |
+| Write | `progbuf2` | `ebreak` |
+| Write | {dm-data0} | address |
+| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-regno} = 0x1008 | Write `s0`
+| Write | {dm-data0} | value0 |
+| Write | {dm-command} | {accessregister-transfer}, {accessregister-write}, {accessregister-postexec}, {accessregister-regno} = 0x1009 | Write `s1`, then execute program buffer
+| Write | {dm-abstractauto} | {abstractauto-autoexecdata}[0] | Set {abstractauto-autoexecdata}[0]
+| Write | {dm-data0} | value1 |
+| ... | ... | ... | ...
+| Write | {dm-data0} | valueN |
+| Write | {dm-abstractauto} | 0 | Clear {abstractauto-autoexecdata}[0]
 |===
 
 [[deb:mwabstract]]
@@ -308,26 +308,26 @@ Write a word to memory using abstract memory access:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | `data1` | address | 
-| Write | {dm-data0} | value | 
-| Write | {dm-command} | cmdtype=2, {accessmemory-aamsize}=2, write=1 | 
+| Op | Address | Value | Comment
+| Write | `data1` | address |
+| Write | {dm-data0} | value |
+| Write | {dm-command} | cmdtype=2, {accessmemory-aamsize}=2, write=1 |
 |===
 
 Write a block of memory using abstract memory access:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | `data1` | address | 
-| Write | {dm-data0} |  value0 | 
-| Write | {dm-command} | cmdtype=2, {accessmemory-aamsize}latexmath:[$=2$], writelatexmath:[$=1$], {accessmemory-aampostincrement}latexmath:[$=1$] | 
-| Write | {dm-abstractauto} | 1 | Re-execute the command when {dm-data0} is accessed 
-| Write | {dm-data0} |  value1 | 
-| Write | {dm-data0} |  value2 | 
-| ... | ... | ... | ... 
-| Write | {dm-data0} |  valueN | 
-| Write | {dm-abstractauto} | 0 | Disable auto-exec 
+| Op | Address | Value | Comment
+| Write | `data1` | address |
+| Write | {dm-data0} |  value0 |
+| Write | {dm-command} | cmdtype=2, {accessmemory-aamsize}latexmath:[$=2$], writelatexmath:[$=1$], {accessmemory-aampostincrement}latexmath:[$=1$] |
+| Write | {dm-abstractauto} | 1 | Re-execute the command when {dm-data0} is accessed
+| Write | {dm-data0} |  value1 |
+| Write | {dm-data0} |  value2 |
+| ... | ... | ... | ...
+| Write | {dm-data0} |  valueN |
+| Write | {dm-abstractauto} | 0 | Disable auto-exec
 |===
 
 ==== Triggers
@@ -344,8 +344,8 @@ used as an instruction breakpoint in ROM:
 
 [%autowidth,align="center",float="center",cols="^,^,^"]
 |===
-| {csr-tdata1} | 0x6980105c | type=6, dmode=1, action=1, select=0, match=0, m=1, s=1, u=1, vs=1, vu=1, execute=1 
-| {csr-tdata2} | 0x80001234 | address 
+| {csr-tdata1} | 0x6980105c | type=6, dmode=1, action=1, select=0, match=0, m=1, s=1, u=1, vs=1, vu=1, execute=1
+| {csr-tdata2} | 0x80001234 | address
 |===
 
 Enter Debug Mode when performing a load at address 0x80007f80 in M-mode
@@ -353,8 +353,8 @@ or S-mode or U-mode:
 
 [%autowidth,align="center",float="center",cols="^,^,^"]
 |===
-| {csr-tdata1} | 0x68001059 | type=6, dmode=1, action=1, select=0, match=0, m=1, s=1, u=1, load=1 
-| {csr-tdata2} | 0x80007f80 | address 
+| {csr-tdata1} | 0x68001059 | type=6, dmode=1, action=1, select=0, match=0, m=1, s=1, u=1, load=1
+| {csr-tdata2} | 0x80007f80 | address
 |===
 
 Enter Debug Mode when storing to an address between 0x80007c80 and
@@ -362,12 +362,12 @@ Enter Debug Mode when storing to an address between 0x80007c80 and
 
 [%autowidth,align="center",float="center",cols="^,^,^"]
 |===
-| {csr-tdata1} 0 | 0x69801902 | type=6, dmode=1, action=1, chain=1, select=0, match=2, vs=1, vu=1, store=1 
-| {csr-tdata2} 0 | 0x80007c80 | start address (inclusive) 
-| {csr-textra32} 0 | 0x03000000 | mhselect=6, mhvalue=0 
-| {csr-tdata1} 1 | 0x69801182 | type=6, dmode=1, action=1, select=0, match=3, vs=1, vu=1, store=1 
-| {csr-tdata2} 1 | 0x80007cf0 | end address (exclusive) 
-| {csr-textra32} 1 | 0x03000000 | mhselect=6, mhvalue=0 
+| {csr-tdata1} 0 | 0x69801902 | type=6, dmode=1, action=1, chain=1, select=0, match=2, vs=1, vu=1, store=1
+| {csr-tdata2} 0 | 0x80007c80 | start address (inclusive)
+| {csr-textra32} 0 | 0x03000000 | mhselect=6, mhvalue=0
+| {csr-tdata1} 1 | 0x69801182 | type=6, dmode=1, action=1, select=0, match=3, vs=1, vu=1, store=1
+| {csr-tdata2} 1 | 0x80007cf0 | end address (exclusive)
+| {csr-textra32} 1 | 0x03000000 | mhselect=6, mhvalue=0
 |===
 
 Enter Debug Mode when storing to an address between 0x81230000 and
@@ -375,8 +375,8 @@ Enter Debug Mode when storing to an address between 0x81230000 and
 
 [%autowidth,align="center",float="center",cols="^,^,^"]
 |===
-| {csr-tdata1} | 0x698010da | type=6, dmode=1, action=1, select=0, match=1, m=1, s=1, u=1, vs=1, vu=1, store=1 
-| {csr-tdata2} | 0x81237fff | 16 upper bits to match exactly, then 0, then all ones. 
+| {csr-tdata1} | 0x698010da | type=6, dmode=1, action=1, select=0, match=1, m=1, s=1, u=1, vs=1, vu=1, store=1
+| {csr-tdata2} | 0x81237fff | 16 upper bits to match exactly, then 0, then all ones.
 |===
 
 Enter Debug Mode when loading from an address between 0x86753090 and
@@ -384,10 +384,10 @@ Enter Debug Mode when loading from an address between 0x86753090 and
 
 [%autowidth,align="center",float="center",cols="^,^,^"]
 |===
-| {csr-tdata1} 0 | 0x69801a59 | type=6, dmode=1, action=1, chain=1, match=4, m=1, s=1, u=1, vs=1, vu=1, load=1 
-| {csr-tdata2} 0 | 0xfff03090 | Mask for low half, then match for low half 
-| {csr-tdata1} 1 | 0x698012d9 | type=6, dmode=1, action=1, match=5, m=1, s=1, u=1, vs=1, vu=1, load=1 
-| {csr-tdata2} 1 | 0xefff8675 | Mask for high half, then match for high half 
+| {csr-tdata1} 0 | 0x69801a59 | type=6, dmode=1, action=1, chain=1, match=4, m=1, s=1, u=1, vs=1, vu=1, load=1
+| {csr-tdata2} 0 | 0xfff03090 | Mask for low half, then match for low half
+| {csr-tdata1} 1 | 0x698012d9 | type=6, dmode=1, action=1, match=5, m=1, s=1, u=1, vs=1, vu=1, load=1
+| {csr-tdata2} 1 | 0xefff8675 | Mask for high half, then match for high half
 |===
 
 ==== Handling Exceptions
@@ -417,18 +417,18 @@ write:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-progbuf0} | `transfer arg2, s0` | Save `s0` 
-| Write | `progbuf1` | `transfer s0, arg0` | Read first argument (address) 
-| Write | `progbuf2` | `transfer arg0, s1` | Save `s1` 
-| Write | `progbuf3` | `transfer s1, arg1` | Read second argument (data) 
-| Write | `progbuf4` | `sw s1, 0(s0)` | 
-| Write | `progbuf5` | `transfer s1, arg0` | Restore `s1` 
-| Write | `progbuf6` | `transfer s0, arg2` | Restore `s0` 
-| Write | `progbuf7` | `ebreak` | 
-| Write | {dm-data0} | address | 
-| Write | `data1` | data | 
-| Write | {dm-command} | 0x10000000 | Perform quick access 
+| Op | Address | Value | Comment
+| Write | {dm-progbuf0} | `transfer arg2, s0` | Save `s0`
+| Write | `progbuf1` | `transfer s0, arg0` | Read first argument (address)
+| Write | `progbuf2` | `transfer arg0, s1` | Save `s1`
+| Write | `progbuf3` | `transfer s1, arg1` | Read second argument (data)
+| Write | `progbuf4` | `sw s1, 0(s0)` |
+| Write | `progbuf5` | `transfer s1, arg0` | Restore `s1`
+| Write | `progbuf6` | `transfer s0, arg2` | Restore `s0`
+| Write | `progbuf7` | `ebreak` |
+| Write | {dm-data0} | address |
+| Write | `data1` | data |
+| Write | {dm-command} | 0x10000000 | Perform quick access
 |===
 
 This shows an example of setting the {mcontrol-m} bit in to enable a hardware
@@ -437,13 +437,13 @@ used previously to configure the trigger that is being enabled here:
 
 [align="center",float="center",cols="^3,^3,^10,<10",options="header"]
 |===
-| Op | Address | Value | Comment 
-| Write | {dm-progbuf0} |  `transfer arg0, s0` | Save `s0` 
-| Write | `progbuf1` | `li s0, (1 << 6)` | Form the mask for {mcontrol-m} bit 
-| Write | `progbuf2` | `csrrs x0, {csr-tdata1}, s0` | Apply the mask to {csr-mcontrol} 
-| Write | `progbuf3` | `transfer s0, arg2` | Restore `s0` 
-| Write | `progbuf4` | `ebreak` | 
-| Write | {dm-command} | 0x10000000 | Perform quick access 
+| Op | Address | Value | Comment
+| Write | {dm-progbuf0} |  `transfer arg0, s0` | Save `s0`
+| Write | `progbuf1` | `li s0, (1 << 6)` | Form the mask for {mcontrol-m} bit
+| Write | `progbuf2` | `csrrs x0, {csr-tdata1}, s0` | Apply the mask to {csr-mcontrol}
+| Write | `progbuf3` | `transfer s0, arg2` | Restore `s0`
+| Write | `progbuf4` | `ebreak` |
+| Write | {dm-command} | 0x10000000 | Perform quick access
 |===
 
 === Native Debugger Implementation
@@ -454,7 +454,7 @@ This section describes how some common tasks might be achieved.
 [[nativestep]]
 ==== Single Step
 
-Single step is straightforward if the OS or a debug stub runs in M-Mode while the
+Single step is straightforward if the OS or a debug stub runs in M-mode while the
 program being debugged runs in a less privileged mode. When a step is required,
 the OS or debug stub writes {icount-count}=1, {icount-action}=0,
 {icount-m}=0 before returning control to the lower user program with an

--- a/dtm.adoc
+++ b/dtm.adoc
@@ -91,8 +91,7 @@ function of each pin is described in <<tab:pinout>>.
 |===
 
 If a hardware platform requires nTRST then it is permissible to reuse
-the nRESET pin as the nTRST signal, resulting in a MIPI 10-pin JTAG +
-nTRST connector.
+the nRESET pin as the nTRST signal, resulting in a MIPI 10-pin JTAG + nTRST connector.
 
 ===== Alternate JTAG Connector
 

--- a/jtagdtm.adoc
+++ b/jtagdtm.adoc
@@ -108,8 +108,7 @@ This signal should only be used to support legacy components that rely
 on this functionality. +
 
 If a hardware platform requires nTRST then it is permissible to reuse
-the nRESET pin as the nTRST signal, resulting in a MIPI 10-pin JTAG +
-nTRST connector.
+the nRESET pin as the nTRST signal, resulting in a MIPI 10-pin JTAG + nTRST connector.
 
 ==== Alternate JTAG Connector
 

--- a/xml/hwbp_registers.xml
+++ b/xml/hwbp_registers.xml
@@ -240,20 +240,20 @@ same project unless stated otherwise.
         This optional register may be implemented only if the H extension is
         implemented. If it is implemented, {csr-mcontext} must also be implemented.
 
-        This register is only accessible in HS-Mode, M-mode and Debug Mode. If
-        Smstateen is implemented, then accessibility of in HS-Mode is
-        controlled by `mstateenzero[57]`.
+        This register is only accessible in HS-mode, M-mode and Debug Mode. If
+        Smstateen is implemented, then accessibility of in HS-mode is
+        controlled by `mstateen0[57]`.
 
         This register is an alias of the {csr-mcontext} register, providing
-        access to the {mcontext-hcontext} field from HS-Mode.
+        access to the {mcontext-hcontext} field from HS-mode.
     </register>
 
     <register name="Supervisor Context" short="scontext" address="0x5a8">
         This optional register is only accessible in S/HS-mode, VS-mode,
         M-mode and Debug Mode.
 
-        Accessibility of this CSR is controlled by `mstateenzero[57]` and
-        `hstateenzero[57]` in the Smstateen extension.  Enabling {csr-scontext}
+        Accessibility of this CSR is controlled by `mstateen0[57]` and
+        `hstateen0[57]` in the Smstateen extension.  Enabling {csr-scontext}
         can be a security risk in a virtualized system with a hypervisor that
         does not swap {csr-scontext}.
         <field name="0" bits="XLEN-1:32" access="R" reset="0" />
@@ -276,13 +276,13 @@ same project unless stated otherwise.
         ====
             {mcontext-hcontext} is primarily useful to set triggers on
             hypervisor systems that only fire when a given VM is executing. It
-            is also useful in systems where M-Mode implements something like a
+            is also useful in systems where M-mode implements something like a
             hypervisor directly.
         ====
 
         <field name="0" bits="XLEN-1:14" access="R" reset="0" />
         <field name="hcontext" bits="13:0" access="WARL" reset="0">
-            M-Mode or HS-Mode (using {csr-hcontext}) software can write a context
+            M-mode or HS-mode (using {csr-hcontext}) software can write a context
             number to this register, which can be used to set triggers that only
             fire in that specific context.
 


### PR DESCRIPTION
Changed M-Mode to M-mode to be consistent with privileged specification.

Renamed mstateenzero to mstateen0 to be consistent with privileged spec

Adjusted line break in "JTAG + nTRST" to avoid rendering issue.

Deleted blank spaces at ends of lines to be consistent with pre-commit requirements in riscv-isa-manual