### PR TITLE
Fix typo in "Reset" section (hasresethaltreq -> halt-on-reset bits)

### DIFF
--- a/Sdext.adoc
+++ b/Sdext.adoc
@@ -168,7 +168,7 @@ xref:nativestep[].
 === Reset
 
 If the halt signal (driven by the hart's halt request bit in the Debug
-Module) or {dmstatus-hasresethaltreq} are asserted when a hart comes out of reset, the hart must
+Module) or halt-on-reset bits are asserted when a hart comes out of reset, the hart must
 enter Debug Mode before executing any instructions, but after performing
 any initialization that would usually happen before the first
 instruction is executed.


### PR DESCRIPTION
This PR corrects a typo in the section titled "Reset".

As discussed in the issue, the text incorrectly referred to hasresethaltreq (the feature support bit) instead of the functional "halt-on-reset bits" which actually cause the halt.

This change makes this section consistent with the terminology used in Section titled "Run Control".