### PR TITLE
Fix typo in "Reset" section

### DIFF
--- a/Sdext.adoc
+++ b/Sdext.adoc
@@ -168,7 +168,7 @@ xref:nativestep[].
 === Reset
 
 If the halt signal (driven by the hart's halt request bit in the Debug
-Module) or {dmstatus-hasresethaltreq} are asserted when a hart comes out of reset, the hart must
+Module) or {resethaltreq} are asserted when a hart comes out of reset, the hart must
 enter Debug Mode before executing any instructions, but after performing
 any initialization that would usually happen before the first
 instruction is executed.


### PR DESCRIPTION
Fixes #1173 

This PR corrects a typo in the "Reset" section.

As discussed in the associated issue, the text incorrectly referred to `hasresethaltreq`. This bit is defined in `dmstatus` (Section 3.14.1) and only indicates if the halt-on-reset *feature* is supported, not the *request* itself.

This commit changes it to `resethaltreq`, which is the conceptual per-hart request bit used in other sections (e.g., Section 3.14.2 and 3.2).