### PR TITLE
Clarify dcsr.cause description about halt groups

### DIFF
--- a/debug_module.adoc
+++ b/debug_module.adoc
@@ -245,10 +245,9 @@ When any hart in a halt group halts:
 . That hart halts normally, with {dcsr-cause} reflecting the original cause of the
 halt.
 . All the other harts in the halt group that are running will quickly
-halt. {dcsr-cause} for those harts should be set to 6, but may be set to 3. Other
-harts in the halt group that are halted but have started the process of
-resuming must also quickly become halted, even if they do resume
-briefly.
+halt. {dcsr-cause} for those harts should be set to 6. Other harts in
+the halt group that are halted but have started the process of resuming
+must also quickly become halted, even if they do resume briefly.
 . Any external triggers in that group are notified.
 
 Adding a hart to a halt group does not automatically halt that hart,
@@ -257,9 +256,9 @@ even if other harts in the group are already halted.
 When an external trigger that's a member of the halt group fires:
 
 . All the harts in the halt group that are running will quickly halt. {dcsr-cause} for
-those harts should be set to 6, but may be set to 3. Other harts in the
-halt group that are halted but have started the process of resuming must
-also quickly become halted, even if they do resume briefly.
+those harts should be set to 6. Other harts in the halt group that are
+halted but have started the process of resuming must also quickly become
+halted, even if they do resume briefly.
 
 When any hart in a resume group resumes:
 

--- a/xml/core_registers.xml
+++ b/xml/core_registers.xml
@@ -263,7 +263,6 @@ same project unless stated otherwise.
 
             <value v="6" name="group">
             The hart halted because it's part of a halt group.
-            Harts may report 3 for this cause instead.
             </value>
 
             <value v="7" name="other">


### PR DESCRIPTION
when hen any hart in a halt group halts, dcsr.cause for Other harts in the halt group should be set to only 6. If dcsr.cause set to 3, can not reflect that the harts is in debug state passively and make a confuse when SMP group is in an inconsistent state. 
relate PR: https://github.com/riscv-collab/riscv-openocd/pull/1171